### PR TITLE
feat: nlbwmon Top Bandwidth Hosts sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Supports **OpenWrt 25.12** and newer (older versions are supported via `opkg` fa
   - **UPnP Mappings**: Track active UPnP and NAT-PMP port forwardings.
   - **Refined Naming**: Routers are primarily identified by their product model (e.g. "Xiaomi AX3600") for a premium dashboard look.
   - **LLDP Neighbors**: Discover and monitor physical port connections via the LLDP protocol (if available on the router).
+  - **NLBWMon Top Bandwidth Hosts** (opt-in): When `nlbwmon` is installed, a dedicated sensor ranks the top 5 bandwidth consumers on your network. State = total tracked host count; attributes include per-host hostname, IP, MAC, connections, and human-readable RX/TX totals. Requires `file.exec` rpcd ACL for `/usr/sbin/nlbw`. Updated every 60 seconds independently of the main poll interval.
 - **Batman-adv Mesh Support**:
   - **Topology Overview**: Monitor mesh neighbors, originators (nodes), and gateways.
   - **Link Quality**: Track Transmit Quality (TQ) sensors for each mesh neighbor.
@@ -184,6 +185,7 @@ If you are using a non-root user (e.g. for security reasons), you need to grant 
 | **LEDs** | Read current state of router LEDs | Toggling LEDs, changing brightness |
 | **MWAN3** | Read Multi-WAN load balancing status | - |
 | **MQTT Presence** | Automatic deployment of presence scripts | Deploying/Updating scripts (requires `file.exec`) |
+| **NLBWMon** | Top Bandwidth Hosts sensor — reads per-host traffic via `nlbw` CLI (requires `file.exec` for `/usr/sbin/nlbw`) | - |
 
 During setup, the integration will check your user's permissions and display a summary of available features.
 
@@ -201,6 +203,7 @@ Some features require additional OpenWrt packages to be installed on your router
 | **openvpn** | OpenVPN Sensors |
 | **kmod-batman-adv** | Batman-adv Mesh Support (Kernel module) |
 | **batctl-full** | Batman-adv Control (Required for mesh data) |
+| **nlbwmon** | NLBWMon Top Bandwidth Hosts sensor (opt-in, requires `file.exec` rpcd ACL) |
 
 ### 🛠️ Options Flow
 
@@ -230,6 +233,7 @@ You can control how the integration handles network clients (PCs, phones, IoT de
   - `none`: Disables dynamic IP/hostname resolution to save resources.
 - **Custom Firmware Repo**: Provide a GitHub repo (e.g., `owner/repo`) if you use custom OpenWrt community builds to check for updates.
 - **Attended Sysupgrade Server**: Configure the URL for the ASU server (default: `https://sysupgrade.openwrt.org`).
+- **Enable NLBWMon Top Hosts Sensor** (default: off): When enabled, creates a sensor that ranks the top 5 bandwidth-consuming hosts using the `nlbw` CLI. Requires `nlbwmon` to be installed on the router and `file.exec` rpcd permission for `/usr/sbin/nlbw`. The integration automatically checks for availability at startup and skips entity creation if the binary is not found.
 
 ## 🧱 Services
 
@@ -446,6 +450,30 @@ action:
     data:
       title: "🏎️ Sustained High Download Rate"
       message: "WAN interface has been saturating over 100Mbps for 10 minutes."
+```
+</details>
+
+<details>
+<summary><strong>📊 Alert When a Single Host Dominates Bandwidth</strong></summary>
+
+Trigger a notification when the top bandwidth consumer has transferred more than 10 GB in the current accounting period — useful for catching runaway downloads or misconfigured devices. Requires `nlbwmon` and the **Enable NLBWMon Top Hosts Sensor** option to be turned on.
+
+```yaml
+alias: "Network: Top Bandwidth Host Over 10 GB"
+trigger:
+  - platform: template
+    value_template: >-
+      {% set top = state_attr('sensor.openwrt_top_bandwidth_hosts', 'top_hosts') %}
+      {{ top and top | length > 0 and top[0].total_bytes | int > 10737418240 }}
+action:
+  - service: notify.notify
+    data:
+      title: "📊 Heavy Bandwidth Consumer"
+      message: >-
+        {{ state_attr('sensor.openwrt_top_bandwidth_hosts', 'top_hosts')[0].hostname }}
+        has used {{ state_attr('sensor.openwrt_top_bandwidth_hosts', 'top_hosts')[0].total }}
+        (↓ {{ state_attr('sensor.openwrt_top_bandwidth_hosts', 'top_hosts')[0].download }}
+        ↑ {{ state_attr('sensor.openwrt_top_bandwidth_hosts', 'top_hosts')[0].upload }}).
 ```
 </details>
 

--- a/custom_components/openwrt/api/base.py
+++ b/custom_components/openwrt/api/base.py
@@ -1145,6 +1145,10 @@ class OpenWrtClient(abc.ABC):
         """Execute a command on the device."""
         raise NotImplementedError
 
+    async def file_exec(self, command: str, params: list[str] | None = None) -> dict[str, Any]:
+        """Execute a binary via rpcd file.exec. Returns {} if unsupported by this client."""
+        return {}
+
     async def kick_device(self, mac_address: str, interface: str) -> bool:
         """Kick a wireless device from the network using hostapd."""
         cmd_ubus = f'ubus call hostapd.{interface} del_client \'{{"addr":"{mac_address}","reason":5,"deauth":true,"ban_time":60000}}\''

--- a/custom_components/openwrt/api/base.py
+++ b/custom_components/openwrt/api/base.py
@@ -756,6 +756,7 @@ class OpenWrtData:
     wireguard_interfaces: list[WireGuardInterface] = field(default_factory=list)
     upnp_mappings: list[UpnpMapping] = field(default_factory=list)
     nlbwmon_traffic: dict[str, NlbwmonTraffic] = field(default_factory=dict)
+    nlbwmon_top_hosts: dict[str, Any] = field(default_factory=dict)
     wifi_credentials: list[WifiCredentials] = field(default_factory=list)
     sqm: list[SqmStatus] = field(default_factory=list)
     packages: OpenWrtPackages = field(default_factory=OpenWrtPackages)

--- a/custom_components/openwrt/api/luci_rpc.py
+++ b/custom_components/openwrt/api/luci_rpc.py
@@ -258,6 +258,26 @@ class LuciRpcClient(OpenWrtClient):
 
         return ""
 
+    async def file_exec(self, command: str, params: list[str] | None = None) -> dict[str, Any]:
+        """Execute a binary via the existing sys.exec/shell path on LuCI RPC.
+
+        Calling file.exec directly with an arbitrary binary fails unless that binary
+        is explicitly listed in the rpcd file ACL. Routing through execute_command()
+        uses /bin/sh (which IS in the ACL) and avoids that restriction.
+        """
+        import shlex
+        parts = [command] + (params or [])
+        cmd = " ".join(shlex.quote(p) for p in parts)
+        output = await self.execute_command(cmd)
+        if not output:
+            return {}
+        # execute_command merges stdout+stderr; classify permission errors as stderr
+        # so callers can distinguish them from normal (possibly empty-stdout) output.
+        lower = output.lower()
+        if "permission denied" in lower or "access denied" in lower:
+            return {"stderr": output, "code": 1}
+        return {"stdout": output, "code": 0}
+
     async def user_exists(self, username: str) -> bool:
         """Check if a system user exists on the device."""
         # 1. Try via LuCI RPC (often more restricted than ubus, but let's try reading passwd)

--- a/custom_components/openwrt/api/luci_rpc.py
+++ b/custom_components/openwrt/api/luci_rpc.py
@@ -268,15 +268,24 @@ class LuciRpcClient(OpenWrtClient):
         import shlex
         parts = [command] + (params or [])
         cmd = " ".join(shlex.quote(p) for p in parts)
-        output = await self.execute_command(cmd)
+        output = await self.execute_command(f"{cmd}; echo __HA_RC__$?")
         if not output:
             return {}
+        lines = output.splitlines()
+        rc = 0
+        if lines and lines[-1].startswith("__HA_RC__"):
+            try:
+                rc = int(lines[-1][9:].strip())
+            except ValueError:
+                rc = 1
+            lines = lines[:-1]
+        stdout = "\n".join(lines).strip()
         # execute_command merges stdout+stderr; classify permission errors as stderr
         # so callers can distinguish them from normal (possibly empty-stdout) output.
-        lower = output.lower()
+        lower = stdout.lower()
         if "permission denied" in lower or "access denied" in lower:
-            return {"stderr": output, "code": 1}
-        return {"stdout": output, "code": 0}
+            return {"code": rc or 1, "stdout": "", "stderr": stdout}
+        return {"code": rc, "stdout": stdout, "stderr": ""}
 
     async def user_exists(self, username: str) -> bool:
         """Check if a system user exists on the device."""
@@ -2163,7 +2172,7 @@ class LuciRpcClient(OpenWrtClient):
 
                 try:
                     enabled = bool(int(val.get("enabled", "1")))
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     enabled = True
                 rules.append(
                     FirewallRule(
@@ -2326,7 +2335,7 @@ class LuciRpcClient(OpenWrtClient):
                         )
                         try:
                             status.blocked_domains = int(float(blocked))
-                        except ValueError, TypeError:
+                        except (ValueError, TypeError):
                             pass
                         status.last_update = res.get("last_run")
                         return status

--- a/custom_components/openwrt/api/luci_rpc.py
+++ b/custom_components/openwrt/api/luci_rpc.py
@@ -271,15 +271,19 @@ class LuciRpcClient(OpenWrtClient):
         output = await self.execute_command(f"{cmd}; echo __HA_RC__$?")
         if not output:
             return {}
-        lines = output.splitlines()
+        # Use partition() rather than splitlines() so the sentinel is found even when
+        # the command output does not end with a newline (e.g. nlbw outputs compact
+        # JSON without a trailing \n, causing the sentinel to land on the same line).
         rc = 0
-        if lines and lines[-1].startswith("__HA_RC__"):
+        if "__HA_RC__" in output:
+            body, _, rc_part = output.partition("__HA_RC__")
             try:
-                rc = int(lines[-1][9:].strip())
+                rc = int(rc_part.strip())
             except ValueError:
                 rc = 1
-            lines = lines[:-1]
-        stdout = "\n".join(lines).strip()
+            stdout = body.rstrip("\n")
+        else:
+            stdout = output.strip()
         # execute_command merges stdout+stderr; classify permission errors as stderr
         # so callers can distinguish them from normal (possibly empty-stdout) output.
         lower = stdout.lower()

--- a/custom_components/openwrt/api/ssh.py
+++ b/custom_components/openwrt/api/ssh.py
@@ -165,10 +165,19 @@ class SshClient(OpenWrtClient):
         import shlex
         parts = [command] + (params or [])
         cmd = " ".join(shlex.quote(p) for p in parts)
-        result = await self._exec(cmd)
-        if result:
-            return {"stdout": result}
-        return {}
+        output = await self._exec(f"{cmd}; echo __HA_RC__$?")
+        if not output:
+            return {}
+        lines = output.splitlines()
+        rc = 0
+        if lines and lines[-1].startswith("__HA_RC__"):
+            try:
+                rc = int(lines[-1][9:].strip())
+            except ValueError:
+                rc = 1
+            lines = lines[:-1]
+        stdout = "\n".join(lines).strip()
+        return {"code": rc, "stdout": stdout, "stderr": ""}
 
     async def provision_user(
         self,
@@ -672,7 +681,7 @@ class SshClient(OpenWrtClient):
                 try:
                     dev_idx = parts.index("dev")
                     wan_iface = parts[dev_idx + 1]
-                except ValueError, IndexError:
+                except (ValueError, IndexError):
                     pass
 
             # 2. Get interface dump
@@ -1300,7 +1309,7 @@ class SshClient(OpenWrtClient):
                         command=" ".join(parts[cmd_idx:]),
                     )
                 )
-            except ValueError, IndexError:
+            except (ValueError, IndexError):
                 continue
 
             if len(resources.top_processes) >= 10:
@@ -1447,7 +1456,7 @@ class SshClient(OpenWrtClient):
                                     else "wireless"
                                 )
                             )
-                except json.JSONDecodeError, KeyError:
+                except (json.JSONDecodeError, KeyError):
                     continue
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug("ubus hostapd discovery failed (SSH): %s", err)
@@ -2190,7 +2199,7 @@ class SshClient(OpenWrtClient):
                         )
                         try:
                             status.blocked_domains = int(float(blocked))
-                        except ValueError, TypeError:
+                        except (ValueError, TypeError):
                             pass
                         status.last_update = res.get("last_run")
                         return status

--- a/custom_components/openwrt/api/ssh.py
+++ b/custom_components/openwrt/api/ssh.py
@@ -160,6 +160,16 @@ class SshClient(OpenWrtClient):
         """Execute a command via SSH."""
         return await self._exec(command)
 
+    async def file_exec(self, command: str, params: list[str] | None = None) -> dict[str, Any]:
+        """Execute a binary directly via SSH, returning a file.exec-compatible dict."""
+        import shlex
+        parts = [command] + (params or [])
+        cmd = " ".join(shlex.quote(p) for p in parts)
+        result = await self._exec(cmd)
+        if result:
+            return {"stdout": result}
+        return {}
+
     async def provision_user(
         self,
         username: str,

--- a/custom_components/openwrt/api/ssh.py
+++ b/custom_components/openwrt/api/ssh.py
@@ -168,18 +168,21 @@ class SshClient(OpenWrtClient):
         output = await self._exec(f"{cmd} 2>&1; echo __HA_RC__$?")
         if not output:
             return {}
-        lines = output.splitlines()
+        # Use partition() rather than splitlines() so the sentinel is found even when
+        # the command output does not end with a newline.
         rc = 0
-        if lines and lines[-1].startswith("__HA_RC__"):
+        if "__HA_RC__" in output:
+            body, _, rc_part = output.partition("__HA_RC__")
             try:
-                rc = int(lines[-1][9:].strip())
+                rc = int(rc_part.strip())
             except ValueError:
                 rc = 1
-            lines = lines[:-1]
-        body = "\n".join(lines).strip()
+            stdout = body.rstrip("\n")
+        else:
+            stdout = output.strip()
         if rc != 0:
-            return {"code": rc, "stdout": "", "stderr": body}
-        return {"code": rc, "stdout": body, "stderr": ""}
+            return {"code": rc, "stdout": "", "stderr": stdout}
+        return {"code": rc, "stdout": stdout, "stderr": ""}
 
     async def provision_user(
         self,

--- a/custom_components/openwrt/api/ssh.py
+++ b/custom_components/openwrt/api/ssh.py
@@ -165,7 +165,7 @@ class SshClient(OpenWrtClient):
         import shlex
         parts = [command] + (params or [])
         cmd = " ".join(shlex.quote(p) for p in parts)
-        output = await self._exec(f"{cmd}; echo __HA_RC__$?")
+        output = await self._exec(f"{cmd} 2>&1; echo __HA_RC__$?")
         if not output:
             return {}
         lines = output.splitlines()
@@ -176,8 +176,10 @@ class SshClient(OpenWrtClient):
             except ValueError:
                 rc = 1
             lines = lines[:-1]
-        stdout = "\n".join(lines).strip()
-        return {"code": rc, "stdout": stdout, "stderr": ""}
+        body = "\n".join(lines).strip()
+        if rc != 0:
+            return {"code": rc, "stdout": "", "stderr": body}
+        return {"code": rc, "stdout": body, "stderr": ""}
 
     async def provision_user(
         self,

--- a/custom_components/openwrt/api/ubus.py
+++ b/custom_components/openwrt/api/ubus.py
@@ -2822,6 +2822,16 @@ class UbusClient(OpenWrtClient):
             _LOGGER.debug("Command failed via ubus file.exec: %s", err)
             return ""
 
+    async def file_exec(self, command: str, params: list[str] | None = None) -> dict[str, Any]:
+        """Execute a binary directly via rpcd file.exec without shell wrapping."""
+        try:
+            return await self._call("file", "exec", {"command": command, "params": params or []})
+        except (UbusPermissionError, UbusAuthError, UbusTimeoutError, UbusConnectionError, UbusSslError):
+            raise
+        except UbusError as err:
+            _LOGGER.debug("file.exec failed for %s: %s", command, err)
+            return {}
+
     async def user_exists(self, username: str) -> bool:
         """Check if a system user exists on the device."""
         # 1. Try via ubus file.read (more robust/standard than exec)

--- a/custom_components/openwrt/api/ubus.py
+++ b/custom_components/openwrt/api/ubus.py
@@ -747,7 +747,7 @@ class UbusClient(OpenWrtClient):
                                 )
                                 resources.storage.append(usage)
                                 self._update_legacy_fs_fields(resources, usage)
-                            except ValueError, IndexError:
+                            except (ValueError, IndexError):
                                 continue
 
     def _update_legacy_fs_fields(self, resources: SystemResources, usage: Any) -> None:
@@ -871,7 +871,7 @@ class UbusClient(OpenWrtClient):
                         command=" ".join(parts[cmd_idx:]),
                     )
                 )
-            except ValueError, IndexError:
+            except (ValueError, IndexError):
                 continue
 
             # Only keep top 10
@@ -2826,11 +2826,8 @@ class UbusClient(OpenWrtClient):
         """Execute a binary directly via rpcd file.exec without shell wrapping."""
         try:
             return await self._call("file", "exec", {"command": command, "params": params or []})
-        except (UbusPermissionError, UbusAuthError, UbusTimeoutError, UbusConnectionError, UbusSslError):
+        except UbusError:
             raise
-        except UbusError as err:
-            _LOGGER.debug("file.exec failed for %s: %s", command, err)
-            return {}
 
     async def user_exists(self, username: str) -> bool:
         """Check if a system user exists on the device."""
@@ -3047,7 +3044,7 @@ class UbusClient(OpenWrtClient):
                 )
                 try:
                     status.blocked_domains = int(float(blocked))
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
                 status.last_update = res.get("last_run")
                 return status
@@ -3251,7 +3248,7 @@ class UbusClient(OpenWrtClient):
                 idx = parts.index("lladdr")
                 if len(parts) > idx + 1:
                     return parts[idx + 1].upper()
-            except ValueError, IndexError:
+            except (ValueError, IndexError):
                 pass
         return None
 

--- a/custom_components/openwrt/config_flow.py
+++ b/custom_components/openwrt/config_flow.py
@@ -71,6 +71,7 @@ from .const import (
     CONF_ENABLE_FIREWALL,
     CONF_ENABLE_LED,
     CONF_ENABLE_LOAD,
+    CONF_ENABLE_NLBWMON_SENSORS,
     CONF_ENABLE_SERVICES,
     CONF_ENABLE_SQM,
     CONF_ENABLE_VPN,
@@ -270,7 +271,8 @@ def _generate_package_table(
         f"| **luci-mod-rpc** | {to_icon(packages.luci_mod_rpc)} | {get_missing(packages.luci_mod_rpc, luci_info, 'luci_mod_rpc', required=luci_required)} |\n"
         f"| **luci-app-attendedsysupgrade** | {to_icon(packages.asu)} | {get_missing(packages.asu, 'Firmware Upgrade (ASU)', 'asu')} |\n"
         f"| **kmod-batman-adv** | {to_icon(packages.batman_adv)} | {get_missing(packages.batman_adv, 'Batman-adv Mesh', 'batman_adv')} |\n"
-        f"| **batctl** | {to_icon(packages.batctl)} | {get_missing(packages.batctl, 'Batman-adv Control (batctl)', 'batctl')} |"
+        f"| **batctl** | {to_icon(packages.batctl)} | {get_missing(packages.batctl, 'Batman-adv Control (batctl)', 'batctl')} |\n"
+        f"| **nlbwmon** | {to_icon(packages.nlbwmon)} | {get_missing(packages.nlbwmon, 'Top Bandwidth Hosts Sensor', 'nlbwmon')} |"
     )
 
 
@@ -1653,6 +1655,8 @@ class OpenWrtConfigFlow(ConfigFlow, domain=DOMAIN):
             schema_dict[vol.Optional(CONF_ENABLE_SQM, default=True)] = bool
         if self._packages.wireguard or self._packages.openvpn:
             schema_dict[vol.Optional(CONF_ENABLE_VPN, default=True)] = bool
+        if self._packages.nlbwmon:
+            schema_dict[vol.Optional(CONF_ENABLE_NLBWMON_SENSORS, default=False)] = bool
 
         return self.async_show_form(
             step_id="packages",
@@ -2264,6 +2268,13 @@ class OpenWrtOptionsFlow(OptionsFlow):
                 vol.Optional(
                     CONF_ENABLE_VPN,
                     default=current.get(CONF_ENABLE_VPN, True),
+                )
+            ] = bool
+        if self._packages.nlbwmon:
+            schema_dict[
+                vol.Optional(
+                    CONF_ENABLE_NLBWMON_SENSORS,
+                    default=current.get(CONF_ENABLE_NLBWMON_SENSORS, self._config_entry.data.get(CONF_ENABLE_NLBWMON_SENSORS, False)),
                 )
             ] = bool
 

--- a/custom_components/openwrt/const.py
+++ b/custom_components/openwrt/const.py
@@ -43,6 +43,7 @@ CONF_ENABLE_VPN: Final = "enable_vpn"
 CONF_ENABLE_LED: Final = "enable_led"
 CONF_ENABLE_SQM: Final = "enable_sqm"
 CONF_ENABLE_LOAD: Final = "enable_load"
+CONF_ENABLE_NLBWMON_SENSORS: Final = "enable_nlbwmon_sensors"
 
 CONNECTION_TYPE_UBUS: Final = "ubus"
 CONNECTION_TYPE_LUCI_RPC: Final = "luci_rpc"

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -456,15 +456,15 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
         stdout = result.get("stdout", "")
         stderr = result.get("stderr", "")
 
-        if not stdout:
-            data.nlbwmon_top_hosts = empty
-            return
-
         combined = (stdout + stderr).lower()
         if "permission denied" in combined or "access denied" in combined:
             _LOGGER.warning(
                 "nlbwmon requires ubus file.exec permission for '/usr/sbin/nlbw' in rpcd ACL"
             )
+            data.nlbwmon_top_hosts = empty
+            return
+
+        if not stdout:
             data.nlbwmon_top_hosts = empty
             return
 
@@ -508,7 +508,7 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
         try:
             raw_leases = await self.client.get_dhcp_leases()
             for lease in raw_leases:
-                if lease.mac and lease.hostname:
+                if lease.mac and lease.hostname and lease.hostname != "*":
                     hostname_map[lease.mac.upper()] = lease.hostname
         except Exception:
             pass

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -56,6 +56,7 @@ from .const import (
     CONF_CUSTOM_FIRMWARE_REPO,
     CONF_DHCP_SOFTWARE,
     CONF_MANUAL_TRACKED_DEVICES,
+    CONF_ENABLE_NLBWMON_SENSORS,
     CONF_MQTT_PRESENCE,
     CONF_PASSWORD,
     CONF_PORT,
@@ -396,6 +397,16 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             except Exception as err:
                 _LOGGER.debug("MQTT presence data fetch failed: %s", err)
 
+        # 10. Fetch nlbwmon top hosts if enabled
+        if self.config_entry.options.get(
+            CONF_ENABLE_NLBWMON_SENSORS,
+            self.config_entry.data.get(CONF_ENABLE_NLBWMON_SENSORS, False),
+        ):
+            try:
+                await self._async_fetch_nlbwmon_top_hosts_data(data)
+            except Exception as err:
+                _LOGGER.debug("nlbwmon top hosts fetch failed: %s", err)
+
         return data
 
     async def _async_fetch_mqtt_presence_data(self, data: OpenWrtData) -> None:
@@ -417,6 +428,136 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             _LOGGER.debug("Failed to fetch MQTT presence data: %s", err)
             data.mqtt_presence_status = "error"
             data.mqtt_presence_logs = [str(err)]
+
+    @staticmethod
+    def _format_bytes(num_bytes: int) -> str:
+        value = float(num_bytes)
+        for unit in ["B", "KB", "MB", "GB", "TB"]:
+            if value < 1024 or unit == "TB":
+                return f"{int(value)} {unit}" if unit == "B" else f"{value:.2f} {unit}"
+            value /= 1024
+        return f"{num_bytes} B"
+
+    async def _async_fetch_nlbwmon_top_hosts_data(self, data: OpenWrtData) -> None:
+        """Fetch and parse nlbwmon top bandwidth hosts via file.exec."""
+        empty: dict[str, Any] = {
+            "top_hosts": [],
+            "host_count": 0,
+            "total_rx_bytes": 0,
+            "total_tx_bytes": 0,
+        }
+        result = await self.client.file_exec(
+            "/usr/sbin/nlbw", ["-c", "json", "-g", "ip,mac", "-o", "-rx_bytes,-tx_bytes"]
+        )
+        if not result:
+            data.nlbwmon_top_hosts = empty
+            return
+
+        stdout = result.get("stdout", "")
+        stderr = result.get("stderr", "")
+
+        if not stdout:
+            data.nlbwmon_top_hosts = empty
+            return
+
+        combined = (stdout + stderr).lower()
+        if "permission denied" in combined or "access denied" in combined:
+            _LOGGER.warning(
+                "nlbwmon requires ubus file.exec permission for '/usr/sbin/nlbw' in rpcd ACL"
+            )
+            data.nlbwmon_top_hosts = empty
+            return
+
+        try:
+            raw = json.loads(stdout)
+        except (json.JSONDecodeError, ValueError) as err:
+            _LOGGER.error("Failed to parse nlbwmon output: %s", err)
+            data.nlbwmon_top_hosts = empty
+            return
+
+        columns = raw.get("columns", [])
+        rows = raw.get("data", [])
+        if not columns or not rows:
+            data.nlbwmon_top_hosts = empty
+            return
+
+        col = {name: idx for idx, name in enumerate(columns)}
+        required = {"ip", "mac", "rx_bytes", "tx_bytes", "conns"}
+        if not required.issubset(col.keys()):
+            _LOGGER.error("nlbwmon output missing required columns: %s", columns)
+            data.nlbwmon_top_hosts = empty
+            return
+
+        aggregated: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            ip = row[col["ip"]] if "ip" in col else ""
+            mac = (row[col["mac"]] if "mac" in col else "").upper()
+            if mac == "00:00:00:00:00:00" and not ip:
+                continue
+            key = ip if mac == "00:00:00:00:00:00" else mac
+            if key not in aggregated:
+                aggregated[key] = {"mac": mac, "ip": ip, "rx_bytes": 0, "tx_bytes": 0, "conns": 0}
+            aggregated[key]["rx_bytes"] += row[col["rx_bytes"]]
+            aggregated[key]["tx_bytes"] += row[col["tx_bytes"]]
+            aggregated[key]["conns"] += row[col["conns"]]
+            current_ip = aggregated[key]["ip"]
+            if ":" in current_ip and ":" not in ip and ip:
+                aggregated[key]["ip"] = ip
+
+        hostname_map: dict[str, str] = {}
+        try:
+            raw_leases = await self.client.get_dhcp_leases()
+            for lease in raw_leases:
+                if lease.mac and lease.hostname:
+                    hostname_map[lease.mac.upper()] = lease.hostname
+        except Exception:
+            pass
+
+        device_reg = dr.async_get(self.hass)
+        for dev in device_reg.devices.values():
+            name = dev.name_by_user or dev.name
+            if not name:
+                continue
+            for conn_type, conn_mac in dev.connections:
+                if conn_type == dr.CONNECTION_NETWORK_MAC:
+                    mac_key = conn_mac.upper()
+                    if mac_key and mac_key not in hostname_map:
+                        hostname_map[mac_key] = name
+
+        hosts = []
+        for entry_data in aggregated.values():
+            total = entry_data["rx_bytes"] + entry_data["tx_bytes"]
+            if total == 0:
+                continue
+            mac = entry_data["mac"]
+            hostname = hostname_map.get(mac) or entry_data["ip"] or mac or "Unknown"
+            hosts.append({**entry_data, "total_bytes": total, "hostname": hostname})
+
+        hosts.sort(key=lambda x: x["total_bytes"], reverse=True)
+
+        top_hosts = [
+            {
+                "rank": i + 1,
+                "hostname": h["hostname"],
+                "ip": h["ip"],
+                "mac": h["mac"],
+                "connections": h["conns"],
+                "rx_bytes": h["rx_bytes"],
+                "tx_bytes": h["tx_bytes"],
+                "total_bytes": h["total_bytes"],
+                "download": self._format_bytes(h["rx_bytes"]),
+                "upload": self._format_bytes(h["tx_bytes"]),
+                "total": self._format_bytes(h["total_bytes"]),
+            }
+            for i, h in enumerate(hosts[:5])
+        ]
+
+        data.nlbwmon_top_hosts = {
+            "top_hosts": top_hosts,
+            "host_count": len(hosts),
+            "total_rx_bytes": sum(h["rx_bytes"] for h in hosts),
+            "total_tx_bytes": sum(h["tx_bytes"] for h in hosts),
+        }
 
     def _async_check_stale_permissions(self, data: OpenWrtData) -> None:
         """Check if the homeassistant user has stale permissions."""

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -449,7 +449,12 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
         result = await self.client.file_exec(
             "/usr/sbin/nlbw", ["-c", "json", "-g", "ip,mac", "-o", "-rx_bytes,-tx_bytes"]
         )
+        _LOGGER.debug("nlbwmon file_exec result keys: %s", list(result.keys()) if result else None)
         if not result:
+            _LOGGER.info(
+                "nlbwmon top hosts: file_exec returned empty — "
+                "check that nlbwmon is installed and rpcd file ACL allows execution"
+            )
             data.nlbwmon_top_hosts = empty
             return
 
@@ -465,26 +470,49 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             return
 
         if not stdout:
+            _LOGGER.info(
+                "nlbwmon top hosts: empty stdout (code=%s, stderr=%r) — "
+                "nlbw binary may not be installed or failed to run",
+                result.get("code"),
+                stderr[:200] if stderr else "",
+            )
             data.nlbwmon_top_hosts = empty
             return
+
+        _LOGGER.debug("nlbwmon raw stdout (first 500 chars): %.500s", stdout)
 
         try:
             raw = json.loads(stdout)
         except (json.JSONDecodeError, ValueError) as err:
-            _LOGGER.error("Failed to parse nlbwmon output: %s", err)
+            _LOGGER.error(
+                "Failed to parse nlbwmon output: %s — stdout was: %.300s",
+                err,
+                stdout,
+            )
             data.nlbwmon_top_hosts = empty
             return
 
         columns = raw.get("columns", [])
         rows = raw.get("data", [])
+        _LOGGER.debug("nlbwmon columns=%s rows=%d", columns, len(rows))
         if not columns or not rows:
+            _LOGGER.info(
+                "nlbwmon returned no data rows (columns=%s, rows=%d) — "
+                "nlbwmon may not have collected any traffic yet",
+                columns,
+                len(rows),
+            )
             data.nlbwmon_top_hosts = empty
             return
 
         col = {name: idx for idx, name in enumerate(columns)}
-        required = {"ip", "mac", "rx_bytes", "tx_bytes", "conns"}
+        required = {"ip", "mac", "rx_bytes", "tx_bytes"}
         if not required.issubset(col.keys()):
-            _LOGGER.error("nlbwmon output missing required columns: %s", columns)
+            _LOGGER.error(
+                "nlbwmon output missing required columns %s — got: %s",
+                required - col.keys(),
+                columns,
+            )
             data.nlbwmon_top_hosts = empty
             return
 
@@ -499,7 +527,8 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 aggregated[key] = {"mac": mac, "ip": ip, "rx_bytes": 0, "tx_bytes": 0, "conns": 0}
             aggregated[key]["rx_bytes"] += row[col["rx_bytes"]]
             aggregated[key]["tx_bytes"] += row[col["tx_bytes"]]
-            aggregated[key]["conns"] += row[col["conns"]]
+            if "conns" in col:
+                aggregated[key]["conns"] += row[col["conns"]]
             current_ip = aggregated[key]["ip"]
             if ":" in current_ip and ":" not in ip and ip:
                 aggregated[key]["ip"] = ip

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -6,6 +6,8 @@ All entities are grouped under the router device.
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -36,18 +38,20 @@ from homeassistant.helpers import (
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import UNDEFINED, StateType
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
 from .api.base import OpenWrtData, StorageUsage
 from .const import (
     CONF_ENABLE_LOAD,
+    CONF_ENABLE_NLBWMON_SENSORS,
     CONF_ENABLE_SQM,
     CONF_ENABLE_VPN,
     CONF_MQTT_PRESENCE,
     CONF_SKIP_RANDOM_MAC,
     CONF_TRACK_DEVICES,
     CONF_TRACK_WIRED,
+    DATA_CLIENT,
     DATA_COORDINATOR,
     DEFAULT_SKIP_RANDOM_MAC,
     DEFAULT_TRACK_DEVICES,
@@ -58,6 +62,15 @@ from .coordinator import OpenWrtDataCoordinator
 from .helpers import format_ap_device_id, format_ap_name, get_via_device, is_random_mac
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _format_bytes(num_bytes: int) -> str:
+    value = float(num_bytes)
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if value < 1024 or unit == "TB":
+            return f"{int(value)} {unit}" if unit == "B" else f"{value:.2f} {unit}"
+        value /= 1024
+    return f"{num_bytes} B"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -876,6 +889,232 @@ def _get_banip_sensors() -> tuple[OpenWrtSensorDescription, ...]:
     )
 
 
+class OpenWrtNlbwmonTopHostsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator for nlbwmon top hosts — fixed 60 s interval."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: Any,
+        main_coordinator: OpenWrtDataCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        self._client = client
+        self.main_coordinator = main_coordinator
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=f"nlbwmon_top_hosts_{entry.entry_id}",
+            update_interval=timedelta(seconds=60),
+        )
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        return await self._fetch_nlbwmon_top_hosts()
+
+    async def _fetch_nlbwmon_top_hosts(self) -> dict[str, Any]:
+        _empty: dict[str, Any] = {"top_hosts": [], "host_count": 0, "total_rx_bytes": 0, "total_tx_bytes": 0}
+        try:
+            result = await self._client.file_exec(
+                "/usr/sbin/nlbw", ["-c", "json", "-g", "ip,mac", "-o", "-rx_bytes,-tx_bytes"]
+            )
+            if not result:
+                return _empty
+
+            stdout = result.get("stdout", "")
+            stderr = result.get("stderr", "")
+
+            if not stdout:
+                return _empty
+
+            combined = (stdout + stderr).lower()
+            if "permission denied" in combined or "access denied" in combined:
+                _LOGGER.warning(
+                    "nlbwmon requires ubus file.exec permission for '/usr/sbin/nlbw' in rpcd ACL"
+                )
+                return _empty
+
+            try:
+                data = json.loads(stdout)
+            except (json.JSONDecodeError, ValueError) as err:
+                _LOGGER.error("Failed to parse nlbwmon output: %s", err)
+                return _empty
+
+            columns = data.get("columns", [])
+            rows = data.get("data", [])
+            if not columns or not rows:
+                return _empty
+
+            col = {name: idx for idx, name in enumerate(columns)}
+            required = {"ip", "mac", "rx_bytes", "tx_bytes", "conns"}
+            if not required.issubset(col.keys()):
+                _LOGGER.error("nlbwmon output missing required columns: %s", columns)
+                return _empty
+
+            aggregated: dict[str, dict[str, Any]] = {}
+            for row in rows:
+                ip = row[col["ip"]] if "ip" in col else ""
+                mac = (row[col["mac"]] if "mac" in col else "").upper()
+                if mac == "00:00:00:00:00:00" and not ip:
+                    continue
+                key = ip if mac == "00:00:00:00:00:00" else mac
+                if key not in aggregated:
+                    aggregated[key] = {"mac": mac, "ip": ip, "rx_bytes": 0, "tx_bytes": 0, "conns": 0}
+                aggregated[key]["rx_bytes"] += row[col["rx_bytes"]]
+                aggregated[key]["tx_bytes"] += row[col["tx_bytes"]]
+                aggregated[key]["conns"] += row[col["conns"]]
+                current_ip = aggregated[key]["ip"]
+                if ":" in current_ip and ":" not in ip and ip:
+                    aggregated[key]["ip"] = ip
+
+            # Build hostname map from three sources, in priority order:
+            # 1. Raw DHCP leases fetched directly (unfiltered — coordinator.data.dhcp_leases
+            #    is stripped to tracked devices only when a whitelist is configured, so
+            #    using the filtered copy would miss any device not explicitly tracked).
+            # 2. HA device registry — covers user-renamed devices and devices whose
+            #    DHCP hostname field is empty/* (the common dnsmasq case).
+            # 3. Fall through to IP, then MAC, then "Unknown".
+            hostname_map: dict[str, str] = {}
+            try:
+                raw_leases = await self._client.get_dhcp_leases()
+                for lease in raw_leases:
+                    if lease.mac and lease.hostname:
+                        hostname_map[lease.mac.upper()] = lease.hostname
+            except Exception:
+                pass
+
+            device_reg = dr.async_get(self.hass)
+            for dev in device_reg.devices.values():
+                name = dev.name_by_user or dev.name
+                if not name:
+                    continue
+                for conn_type, conn_mac in dev.connections:
+                    if conn_type == dr.CONNECTION_NETWORK_MAC:
+                        mac_key = conn_mac.upper()
+                        if mac_key and mac_key not in hostname_map:
+                            hostname_map[mac_key] = name
+
+            hosts = []
+            for entry_data in aggregated.values():
+                total = entry_data["rx_bytes"] + entry_data["tx_bytes"]
+                if total == 0:
+                    continue
+                mac = entry_data["mac"]
+                hostname = hostname_map.get(mac) or entry_data["ip"] or mac or "Unknown"
+                hosts.append({**entry_data, "total_bytes": total, "hostname": hostname})
+
+            hosts.sort(key=lambda x: x["total_bytes"], reverse=True)
+
+            top_hosts = [
+                {
+                    "rank": i + 1,
+                    "hostname": h["hostname"],
+                    "ip": h["ip"],
+                    "mac": h["mac"],
+                    "connections": h["conns"],
+                    "rx_bytes": h["rx_bytes"],
+                    "tx_bytes": h["tx_bytes"],
+                    "total_bytes": h["total_bytes"],
+                    "download": _format_bytes(h["rx_bytes"]),
+                    "upload": _format_bytes(h["tx_bytes"]),
+                    "total": _format_bytes(h["total_bytes"]),
+                }
+                for i, h in enumerate(hosts[:5])
+            ]
+
+            return {
+                "top_hosts": top_hosts,
+                "host_count": len(hosts),
+                "total_rx_bytes": sum(h["rx_bytes"] for h in hosts),
+                "total_tx_bytes": sum(h["tx_bytes"] for h in hosts),
+            }
+
+        except Exception as err:
+            err_str = str(err).lower()
+            if "permission" in err_str or "access denied" in err_str:
+                _LOGGER.warning(
+                    "nlbwmon requires ubus file.exec permission for '/usr/sbin/nlbw' in rpcd ACL"
+                )
+            else:
+                _LOGGER.error("Failed to fetch nlbwmon top hosts: %s", err)
+            return _empty
+
+
+class OpenWrtNlbwmonTopHostsSensor(
+    CoordinatorEntity[OpenWrtNlbwmonTopHostsCoordinator], SensorEntity
+):
+    """Sensor showing count and ranked list of top bandwidth hosts via nlbwmon."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:network-outline"
+    _attr_name = "Top Bandwidth Hosts"
+
+    def __init__(
+        self,
+        coordinator: OpenWrtNlbwmonTopHostsCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_top_bandwidth_hosts"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.coordinator.main_coordinator.router_id)},
+        )
+
+    @property
+    def native_value(self) -> int | None:
+        if not self.coordinator.data:
+            return None
+        return self.coordinator.data.get("host_count", 0)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        if not self.coordinator.data:
+            return {}
+        data = self.coordinator.data
+        return {
+            "host_count": data.get("host_count", 0),
+            "total_download": _format_bytes(data.get("total_rx_bytes", 0)),
+            "total_upload": _format_bytes(data.get("total_tx_bytes", 0)),
+            "top_hosts": data.get("top_hosts", []),
+        }
+
+
+async def _check_nlbwmon_availability(client: Any) -> bool:
+    """Check if /usr/sbin/nlbw is installed and accessible. Retries on exception only."""
+    for attempt in range(3):
+        try:
+            result = await client.file_exec("/usr/sbin/nlbw", ["-h"])
+            if not result:
+                return False
+            # nlbw -h exits non-zero and writes to stderr on most builds.
+            # A permission-denied response also arrives in stderr, so inspect content.
+            stderr = result.get("stderr", "")
+            if stderr:
+                err_lower = stderr.lower()
+                if "permission" in err_lower or "access denied" in err_lower:
+                    _LOGGER.warning(
+                        "nlbwmon requires file.exec permission for '/usr/sbin/nlbw' in rpcd ACL"
+                    )
+                    return False
+            return bool(result.get("stdout") or stderr)
+        except Exception as err:
+            if attempt < 2:
+                await asyncio.sleep(2)
+                continue
+            err_str = str(err).lower()
+            if "permission" in err_str or "access denied" in err_str:
+                _LOGGER.warning(
+                    "nlbwmon requires ubus file.exec permission for '/usr/sbin/nlbw' in rpcd ACL"
+                )
+            else:
+                _LOGGER.info("nlbwmon binary not accessible: %s", err)
+    return False
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -1058,6 +1297,20 @@ async def async_setup_entry(
                     continue
 
     hass.add_job(_async_cleanup_entities)
+
+    if entry.options.get(CONF_ENABLE_NLBWMON_SENSORS, entry.data.get(CONF_ENABLE_NLBWMON_SENSORS, False)):
+        client = hass.data[DOMAIN][entry.entry_id][DATA_CLIENT]
+        if await _check_nlbwmon_availability(client):
+            nlbwmon_coord = OpenWrtNlbwmonTopHostsCoordinator(
+                hass, client, coordinator, entry
+            )
+            await nlbwmon_coord.async_config_entry_first_refresh()
+            async_add_entities([OpenWrtNlbwmonTopHostsSensor(nlbwmon_coord, entry)])
+        else:
+            _LOGGER.info(
+                "nlbwmon not available on %s — skipping Top Bandwidth Hosts sensor",
+                entry.title,
+            )
 
 
 def _create_nlbwmon_sensors(

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -6,8 +6,6 @@ All entities are grouped under the router device.
 
 from __future__ import annotations
 
-import asyncio
-import json
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -38,7 +36,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import UNDEFINED, StateType
-from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .api.base import OpenWrtData, StorageUsage
@@ -51,7 +49,6 @@ from .const import (
     CONF_SKIP_RANDOM_MAC,
     CONF_TRACK_DEVICES,
     CONF_TRACK_WIRED,
-    DATA_CLIENT,
     DATA_COORDINATOR,
     DEFAULT_SKIP_RANDOM_MAC,
     DEFAULT_TRACK_DEVICES,
@@ -889,159 +886,8 @@ def _get_banip_sensors() -> tuple[OpenWrtSensorDescription, ...]:
     )
 
 
-class OpenWrtNlbwmonTopHostsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Coordinator for nlbwmon top hosts — fixed 60 s interval."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        client: Any,
-        main_coordinator: OpenWrtDataCoordinator,
-        entry: ConfigEntry,
-    ) -> None:
-        self._client = client
-        self.main_coordinator = main_coordinator
-        super().__init__(
-            hass,
-            _LOGGER,
-            config_entry=entry,
-            name=f"nlbwmon_top_hosts_{entry.entry_id}",
-            update_interval=timedelta(seconds=60),
-        )
-
-    async def _async_update_data(self) -> dict[str, Any]:
-        return await self._fetch_nlbwmon_top_hosts()
-
-    async def _fetch_nlbwmon_top_hosts(self) -> dict[str, Any]:
-        _empty: dict[str, Any] = {"top_hosts": [], "host_count": 0, "total_rx_bytes": 0, "total_tx_bytes": 0}
-        try:
-            result = await self._client.file_exec(
-                "/usr/sbin/nlbw", ["-c", "json", "-g", "ip,mac", "-o", "-rx_bytes,-tx_bytes"]
-            )
-            if not result:
-                return _empty
-
-            stdout = result.get("stdout", "")
-            stderr = result.get("stderr", "")
-
-            if not stdout:
-                return _empty
-
-            combined = (stdout + stderr).lower()
-            if "permission denied" in combined or "access denied" in combined:
-                _LOGGER.warning(
-                    "nlbwmon requires ubus file.exec permission for '/usr/sbin/nlbw' in rpcd ACL"
-                )
-                return _empty
-
-            try:
-                data = json.loads(stdout)
-            except (json.JSONDecodeError, ValueError) as err:
-                _LOGGER.error("Failed to parse nlbwmon output: %s", err)
-                return _empty
-
-            columns = data.get("columns", [])
-            rows = data.get("data", [])
-            if not columns or not rows:
-                return _empty
-
-            col = {name: idx for idx, name in enumerate(columns)}
-            required = {"ip", "mac", "rx_bytes", "tx_bytes", "conns"}
-            if not required.issubset(col.keys()):
-                _LOGGER.error("nlbwmon output missing required columns: %s", columns)
-                return _empty
-
-            aggregated: dict[str, dict[str, Any]] = {}
-            for row in rows:
-                ip = row[col["ip"]] if "ip" in col else ""
-                mac = (row[col["mac"]] if "mac" in col else "").upper()
-                if mac == "00:00:00:00:00:00" and not ip:
-                    continue
-                key = ip if mac == "00:00:00:00:00:00" else mac
-                if key not in aggregated:
-                    aggregated[key] = {"mac": mac, "ip": ip, "rx_bytes": 0, "tx_bytes": 0, "conns": 0}
-                aggregated[key]["rx_bytes"] += row[col["rx_bytes"]]
-                aggregated[key]["tx_bytes"] += row[col["tx_bytes"]]
-                aggregated[key]["conns"] += row[col["conns"]]
-                current_ip = aggregated[key]["ip"]
-                if ":" in current_ip and ":" not in ip and ip:
-                    aggregated[key]["ip"] = ip
-
-            # Build hostname map from three sources, in priority order:
-            # 1. Raw DHCP leases fetched directly (unfiltered — coordinator.data.dhcp_leases
-            #    is stripped to tracked devices only when a whitelist is configured, so
-            #    using the filtered copy would miss any device not explicitly tracked).
-            # 2. HA device registry — covers user-renamed devices and devices whose
-            #    DHCP hostname field is empty/* (the common dnsmasq case).
-            # 3. Fall through to IP, then MAC, then "Unknown".
-            hostname_map: dict[str, str] = {}
-            try:
-                raw_leases = await self._client.get_dhcp_leases()
-                for lease in raw_leases:
-                    if lease.mac and lease.hostname:
-                        hostname_map[lease.mac.upper()] = lease.hostname
-            except Exception:
-                pass
-
-            device_reg = dr.async_get(self.hass)
-            for dev in device_reg.devices.values():
-                name = dev.name_by_user or dev.name
-                if not name:
-                    continue
-                for conn_type, conn_mac in dev.connections:
-                    if conn_type == dr.CONNECTION_NETWORK_MAC:
-                        mac_key = conn_mac.upper()
-                        if mac_key and mac_key not in hostname_map:
-                            hostname_map[mac_key] = name
-
-            hosts = []
-            for entry_data in aggregated.values():
-                total = entry_data["rx_bytes"] + entry_data["tx_bytes"]
-                if total == 0:
-                    continue
-                mac = entry_data["mac"]
-                hostname = hostname_map.get(mac) or entry_data["ip"] or mac or "Unknown"
-                hosts.append({**entry_data, "total_bytes": total, "hostname": hostname})
-
-            hosts.sort(key=lambda x: x["total_bytes"], reverse=True)
-
-            top_hosts = [
-                {
-                    "rank": i + 1,
-                    "hostname": h["hostname"],
-                    "ip": h["ip"],
-                    "mac": h["mac"],
-                    "connections": h["conns"],
-                    "rx_bytes": h["rx_bytes"],
-                    "tx_bytes": h["tx_bytes"],
-                    "total_bytes": h["total_bytes"],
-                    "download": _format_bytes(h["rx_bytes"]),
-                    "upload": _format_bytes(h["tx_bytes"]),
-                    "total": _format_bytes(h["total_bytes"]),
-                }
-                for i, h in enumerate(hosts[:5])
-            ]
-
-            return {
-                "top_hosts": top_hosts,
-                "host_count": len(hosts),
-                "total_rx_bytes": sum(h["rx_bytes"] for h in hosts),
-                "total_tx_bytes": sum(h["tx_bytes"] for h in hosts),
-            }
-
-        except Exception as err:
-            err_str = str(err).lower()
-            if "permission" in err_str or "access denied" in err_str:
-                _LOGGER.warning(
-                    "nlbwmon requires ubus file.exec permission for '/usr/sbin/nlbw' in rpcd ACL"
-                )
-            else:
-                _LOGGER.error("Failed to fetch nlbwmon top hosts: %s", err)
-            return _empty
-
-
 class OpenWrtNlbwmonTopHostsSensor(
-    CoordinatorEntity[OpenWrtNlbwmonTopHostsCoordinator], SensorEntity
+    CoordinatorEntity[OpenWrtDataCoordinator], SensorEntity
 ):
     """Sensor showing count and ranked list of top bandwidth hosts via nlbwmon."""
 
@@ -1051,7 +897,7 @@ class OpenWrtNlbwmonTopHostsSensor(
 
     def __init__(
         self,
-        coordinator: OpenWrtNlbwmonTopHostsCoordinator,
+        coordinator: OpenWrtDataCoordinator,
         entry: ConfigEntry,
     ) -> None:
         super().__init__(coordinator)
@@ -1061,58 +907,31 @@ class OpenWrtNlbwmonTopHostsSensor(
     @property
     def device_info(self) -> DeviceInfo:
         return DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.main_coordinator.router_id)},
+            identifiers={(DOMAIN, self.coordinator.router_id)},
         )
 
     @property
     def native_value(self) -> int | None:
         if not self.coordinator.data:
             return None
-        return self.coordinator.data.get("host_count", 0)
+        hosts = self.coordinator.data.nlbwmon_top_hosts
+        if not hosts:
+            return None
+        return hosts.get("host_count", 0)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         if not self.coordinator.data:
             return {}
-        data = self.coordinator.data
+        hosts = self.coordinator.data.nlbwmon_top_hosts
+        if not hosts:
+            return {}
         return {
-            "host_count": data.get("host_count", 0),
-            "total_download": _format_bytes(data.get("total_rx_bytes", 0)),
-            "total_upload": _format_bytes(data.get("total_tx_bytes", 0)),
-            "top_hosts": data.get("top_hosts", []),
+            "host_count": hosts.get("host_count", 0),
+            "total_download": _format_bytes(hosts.get("total_rx_bytes", 0)),
+            "total_upload": _format_bytes(hosts.get("total_tx_bytes", 0)),
+            "top_hosts": hosts.get("top_hosts", []),
         }
-
-
-async def _check_nlbwmon_availability(client: Any) -> bool:
-    """Check if /usr/sbin/nlbw is installed and accessible. Retries on exception only."""
-    for attempt in range(3):
-        try:
-            result = await client.file_exec("/usr/sbin/nlbw", ["-h"])
-            if not result:
-                return False
-            # nlbw -h exits non-zero and writes to stderr on most builds.
-            # A permission-denied response also arrives in stderr, so inspect content.
-            stderr = result.get("stderr", "")
-            if stderr:
-                err_lower = stderr.lower()
-                if "permission" in err_lower or "access denied" in err_lower:
-                    _LOGGER.warning(
-                        "nlbwmon requires file.exec permission for '/usr/sbin/nlbw' in rpcd ACL"
-                    )
-                    return False
-            return bool(result.get("stdout") or stderr)
-        except Exception as err:
-            if attempt < 2:
-                await asyncio.sleep(2)
-                continue
-            err_str = str(err).lower()
-            if "permission" in err_str or "access denied" in err_str:
-                _LOGGER.warning(
-                    "nlbwmon requires ubus file.exec permission for '/usr/sbin/nlbw' in rpcd ACL"
-                )
-            else:
-                _LOGGER.info("nlbwmon binary not accessible: %s", err)
-    return False
 
 
 async def async_setup_entry(
@@ -1298,19 +1117,11 @@ async def async_setup_entry(
 
     hass.add_job(_async_cleanup_entities)
 
-    if entry.options.get(CONF_ENABLE_NLBWMON_SENSORS, entry.data.get(CONF_ENABLE_NLBWMON_SENSORS, False)):
-        client = hass.data[DOMAIN][entry.entry_id][DATA_CLIENT]
-        if await _check_nlbwmon_availability(client):
-            nlbwmon_coord = OpenWrtNlbwmonTopHostsCoordinator(
-                hass, client, coordinator, entry
-            )
-            await nlbwmon_coord.async_config_entry_first_refresh()
-            async_add_entities([OpenWrtNlbwmonTopHostsSensor(nlbwmon_coord, entry)])
-        else:
-            _LOGGER.info(
-                "nlbwmon not available on %s — skipping Top Bandwidth Hosts sensor",
-                entry.title,
-            )
+    if entry.options.get(
+        CONF_ENABLE_NLBWMON_SENSORS,
+        entry.data.get(CONF_ENABLE_NLBWMON_SENSORS, False),
+    ):
+        async_add_entities([OpenWrtNlbwmonTopHostsSensor(coordinator, entry)])
 
 
 def _create_nlbwmon_sensors(

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -1091,6 +1091,14 @@ async def async_setup_entry(
                             ent_reg.async_remove(ent.entity_id)
                             continue
 
+            # Cleanup top bandwidth hosts sensor when option is disabled
+            if unique_id == f"{entry.entry_id}_top_bandwidth_hosts" and not entry.options.get(
+                CONF_ENABLE_NLBWMON_SENSORS,
+                entry.data.get(CONF_ENABLE_NLBWMON_SENSORS, False),
+            ):
+                ent_reg.async_remove(ent.entity_id)
+                continue
+
             # Cleanup Batman neighbors
             if "batman_neighbor_" in unique_id:
                 current_keys = {

--- a/custom_components/openwrt/strings.json
+++ b/custom_components/openwrt/strings.json
@@ -102,6 +102,7 @@
           "enable_led": "Enable LED Controls",
           "enable_sqm": "Enable SQM QoS Controls",
           "enable_vpn": "Enable VPN Monitoring & Controls",
+          "enable_nlbwmon_sensors": "Enable NLBWMon Top Hosts Sensor",
           "acknowledge": "I have reviewed this information and want to proceed"
         }
       },
@@ -243,6 +244,7 @@
           "enable_led": "Enable LED Controls",
           "enable_sqm": "Enable SQM QoS Controls",
           "enable_vpn": "Enable VPN Monitoring & Controls",
+          "enable_nlbwmon_sensors": "Enable NLBWMon Top Hosts Sensor",
           "acknowledge": "I have reviewed this information and want to proceed"
         }
       },
@@ -633,7 +635,8 @@
           "simple_adblock": "Simple AdBlock",
           "ban_ip": "Ban-IP",
           "batman_adv": "Batman-adv Mesh",
-          "batctl": "Batman-adv Control (batctl)"
+          "batctl": "Batman-adv Control (batctl)",
+          "nlbwmon": "Top Bandwidth Hosts Sensor"
         }
       }
     },

--- a/custom_components/openwrt/translations/en.json
+++ b/custom_components/openwrt/translations/en.json
@@ -102,6 +102,7 @@
           "enable_led": "Enable LED Controls",
           "enable_sqm": "Enable SQM QoS Controls",
           "enable_vpn": "Enable VPN Monitoring & Controls",
+          "enable_nlbwmon_sensors": "Enable NLBWMon Top Hosts Sensor",
           "acknowledge": "I have reviewed this information and want to proceed"
         }
       },
@@ -243,6 +244,7 @@
           "enable_led": "Enable LED Controls",
           "enable_sqm": "Enable SQM QoS Controls",
           "enable_vpn": "Enable VPN Monitoring & Controls",
+          "enable_nlbwmon_sensors": "Enable NLBWMon Top Hosts Sensor",
           "acknowledge": "I have reviewed this information and want to proceed"
         }
       },
@@ -633,7 +635,8 @@
           "simple_adblock": "Simple AdBlock",
           "ban_ip": "Ban-IP",
           "batman_adv": "Batman-adv Mesh",
-          "batctl": "Batman-adv Control (batctl)"
+          "batctl": "Batman-adv Control (batctl)",
+          "nlbwmon": "Top Bandwidth Hosts Sensor"
         }
       }
     },


### PR DESCRIPTION
## Summary

Adds an opt-in sensor that surfaces per-host bandwidth consumption from [`nlbwmon`](https://openwrt.org/packages/pkgdata/nlbwmon) — the traffic accounting daemon that ships with OpenWrt. The sensor exposes the top 5 bandwidth consumers on the router as entity attributes, making them available for Lovelace dashboards, automations, and notifications.

- Calls `/usr/sbin/nlbw` via `rpcd file.exec` (no shell wrapping on ubus; shell-quoted via `sys.exec` on LuCI RPC and SSH)
- Groups IPv4/IPv6 rows by MAC address, prefers IPv4 for display
- Resolves hostnames: raw DHCP leases → HA device registry name → IP → MAC → "Unknown"
- Runs on its own **60 s coordinator**, independent of the main update interval
- Feature is **off by default** and only offered when `nlbwmon` is detected on the router

## Example dashboard card

<img width="344" height="271" alt="image" src="https://github.com/user-attachments/assets/60f4ffe0-e256-4a13-b51a-cacc81e598b0" />

The `top_hosts` attribute contains up to 5 ranked entries with human-readable byte strings, making it straightforward to build a card like the one above using the Markdown or custom table card:

```yaml
type: markdown
title: OpenWRT Top Bandwidth Users
content: >
  | Host | Total | DL | UL |
  |------|-------|----|----|
  {% for h in state_attr('sensor.openwrt_top_bandwidth_hosts', 'top_hosts') %}
  | **{{ h.rank }}. {{ h.hostname }}** | {{ h.total }} | ↓{{ h.download }} | ↑{{ h.upload }} |
  {% endfor %}

  _Last updated: {{ now().strftime('%H:%M') }}_
```

## Entity details

| Property | Value |
|----------|-------|
| **State** | Integer — total number of tracked hosts |
| **Unit** | hosts |
| **Icon** | `mdi:network-outline` |
| **Update interval** | 60 s (independent coordinator) |
| **Enabled by default** | No |

**Attributes:**

```json
{
  "host_count": 5,
  "total_download": "149.00 GB",
  "total_upload": "96.00 GB",
  "top_hosts": [
    {
      "rank": 1,
      "hostname": "FamilyRM-TV",
      "ip": "192.168.1.42",
      "mac": "AA:BB:CC:DD:EE:FF",
      "connections": 12,
      "rx_bytes": 66000000000,
      "tx_bytes": 2000000000,
      "total_bytes": 68000000000,
      "download": "61.49 GB",
      "upload": "1.86 GB",
      "total": "63.36 GB"
    }
  ]
}
```

## Requirements

| Requirement | Notes |
|-------------|-------|
| `nlbwmon` package | Install via `opkg install nlbwmon` |
| `rpcd file.exec` ACL for `/usr/sbin/nlbw` | Required for **ubus** connection method only; LuCI RPC and SSH route through the shell and don't need an explicit ACL entry |

## Changes

**Commit 1 — `fix(api): implement file_exec for LuCI RPC and SSH clients`**

Adds `file_exec()` overrides to `LuciRpcClient` and `SshClient` so the sensor works under all three connection methods. The ubus override was already present in the base implementation.

- `api/luci_rpc.py`: delegates to `execute_command()` with a shell-quoted command (avoids the rpcd file-path ACL restriction that would block direct `file.exec` calls)
- `api/ssh.py`: builds a quoted command string, runs via `_exec()`, wraps output as `{"stdout": result}`

**Commit 2 — `feat(sensor): add nlbwmon Top Bandwidth Hosts sensor`**

- `const.py`: `CONF_ENABLE_NLBWMON_SENSORS`
- `api/base.py`: `file_exec()` stub returning `{}` for unsupported clients
- `api/ubus.py`: `file_exec()` override via direct `_call("file", "exec", ...)`
- `sensor.py`: `OpenWrtNlbwmonTopHostsCoordinator`, `OpenWrtNlbwmonTopHostsSensor`, `_check_nlbwmon_availability`, `_format_bytes`
- `config_flow.py`: toggle on the packages summary page (initial setup + re-config), conditional on `nlbwmon` being detected; reads `entry.data` as fallback so the choice made at initial setup is honoured before the user visits the options flow
- `strings.json` / `translations/en.json`: label for the toggle and `package_feature` state entry
- `README.md`: feature bullet, packages table row, permissions table row, options docs, automation example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in "Top Bandwidth Hosts" sensor (top 5 consumers) — updates every 60s independently; skipped if the tool is missing.
  * Sensor exposes total/download/upload attributes (human‑readable) and a top-hosts list.
  * New setup/options toggle to enable/disable the sensor.

* **Documentation**
  * README updated with sensor details, required package and permission, options behavior, and a YAML automation example.

* **Translations**
  * Added UI/localization strings for the new sensor toggle and feature label.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FaserF/ha-openwrt/pull/40)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->