### PR TITLE
fix: connected/wireless client counts unaffected by device tracking whitelist

### DIFF
--- a/custom_components/openwrt/api/base.py
+++ b/custom_components/openwrt/api/base.py
@@ -721,6 +721,7 @@ class OpenWrtData:
     wireless_interfaces: list[WirelessInterface] = field(default_factory=list)
     network_interfaces: list[NetworkInterface] = field(default_factory=list)
     connected_devices: list[ConnectedDevice] = field(default_factory=list)
+    all_connected_devices: list[ConnectedDevice] = field(default_factory=list)
     dhcp_leases: list[DhcpLease] = field(default_factory=list)
     reboot_required: bool = False
     system_logs: list[str] = field(default_factory=list)

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -626,6 +626,12 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             whitelist = self._async_get_tracked_devices_whitelist()
 
         # 4. Filter connected devices
+        # all_devices: passes internal filters but ignores the tracking whitelist.
+        # Used by the Connected Clients / Wireless Clients count sensors so they
+        # always reflect total router occupancy, not just the selected tracked set.
+        # filtered_devices: additionally requires whitelist membership; used for
+        # device_tracker entities and history.
+        all_devices: list = []
         filtered_devices = []
         for device in data.connected_devices:
             if not device.mac:
@@ -668,6 +674,9 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             ):
                 continue
 
+            # Device passes internal filters — count it in the totals regardless of whitelist
+            all_devices.append(device)
+
             # 5. Handle MQTT Discovery if enabled
             if self.config_entry.options.get(CONF_MQTT_PRESENCE, False):
                 await self._async_discovery_mqtt_device(mac, device.hostname or mac)
@@ -706,6 +715,7 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                     hist["is_wireless"] = True
                 history_updated = True
 
+        data.all_connected_devices = all_devices
         data.connected_devices = filtered_devices
         # 5. Filter DHCP leases by whitelist
         if whitelist:

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -1765,7 +1765,7 @@ def _create_wifi_base_sensors(
                 state_class=SensorStateClass.MEASUREMENT,
                 value_fn=lambda data, n=iface_name, s=section_id, i=ifname: sum(
                     1
-                    for d in data.connected_devices
+                    for d in data.all_connected_devices
                     if d.is_wireless
                     and d.connected
                     and (

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -546,14 +546,18 @@ def _get_system_sensors() -> tuple[OpenWrtSensorDescription, ...]:
             name="Connected Clients",
             translation_key="connected_clients",
             state_class=SensorStateClass.MEASUREMENT,
-            value_fn=lambda data: sum(1 for d in data.connected_devices if d.connected),
+            value_fn=lambda data: sum(
+                1 for d in data.all_connected_devices if d.connected
+            ),
             attrs_fn=lambda data: {
                 "wireless": sum(
-                    1 for d in data.connected_devices if d.is_wireless and d.connected
+                    1
+                    for d in data.all_connected_devices
+                    if d.is_wireless and d.connected
                 ),
                 "wired": sum(
                     1
-                    for d in data.connected_devices
+                    for d in data.all_connected_devices
                     if not d.is_wireless and d.connected
                 ),
             },
@@ -565,7 +569,7 @@ def _get_system_sensors() -> tuple[OpenWrtSensorDescription, ...]:
             state_class=SensorStateClass.MEASUREMENT,
             entity_registry_enabled_default=False,
             value_fn=lambda data: sum(
-                1 for d in data.connected_devices if d.is_wireless and d.connected
+                1 for d in data.all_connected_devices if d.is_wireless and d.connected
             ),
         ),
         OpenWrtSensorDescription(


### PR DESCRIPTION
## Summary

- When **Enable Device Tracking** is on with a device selection (whitelist), `_async_filter_and_track_devices` replaced `data.connected_devices` with only the selected MACs before the count sensors read it — so **Connected Clients**, **Wireless Clients**, and per-AP **Clients** sensors showed the number of *selected* devices, not the actual number of devices on the network.
- Added `all_connected_devices` field to `OpenWrtData` — populated after the internal router-own-device filters (own MACs, own IPs, interface-name hostnames) but **before** the tracking whitelist — and pointed the three count sensors at this unfiltered list.
- `data.connected_devices` continues to hold the whitelist-filtered set for device_tracker entities and history, so tracking behaviour is unchanged.

## Files changed

| File | Change |
|------|--------|
| `api/base.py` | Add `all_connected_devices: list[ConnectedDevice]` field to `OpenWrtData` |
| `coordinator.py` | Populate `all_connected_devices` before whitelist step in `_async_filter_and_track_devices` |
| `sensor.py` | `connected_clients`, `wireless_clients`, and per-AP `wifi_clients` sensors use `all_connected_devices` |

## Test plan

- [ ] Device tracking **disabled** → Connected Clients / Wireless Clients / per-AP Clients unchanged
- [ ] Device tracking **enabled, no device selected** → same as above
- [ ] Device tracking **enabled, subset of devices selected** → Connected Clients shows total router occupancy, not selected count; Wireless Clients shows total wireless; per-AP Clients shows actual station count per AP
- [ ] Device tracker entities still only track the selected devices (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Connected device metrics now reflect all devices connected to the router (not limited by tracked-device whitelist), giving a complete view of router occupancy.
  * "Connected clients" and WiFi client sensors now derive counts and attributes from the full set of connected devices, improving accuracy of wired/wireless breakdowns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FaserF/ha-openwrt/pull/41)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->