### PR TITLE
fix: avoid AttributeError on _attr_name in OpenWrtWifiSensorEntity

### DIFF
--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -162,9 +162,12 @@ class OpenWrtWifiSensorEntity(OpenWrtSensorEntity):
             > 1
         ):
             name_label = f"{name_label} [{iface_name}]"
-            # We also need to update the description name so the entity name reflects this
-            if self._attr_name:
-                self._attr_name = f"{self._attr_name} [{iface_name}]"
+            # We also need to update the description name so the entity name reflects this.
+            # Use getattr to avoid AttributeError on HA versions where _attr_name has no
+            # class-level default until it is explicitly set.
+            existing_name = getattr(self, "_attr_name", None)
+            if existing_name:
+                self._attr_name = f"{existing_name} [{iface_name}]"
             elif description.name:
                 self._attr_name = f"{description.name} [{iface_name}]"
 


### PR DESCRIPTION
## Summary

- Accessing `self._attr_name` in `OpenWrtWifiSensorEntity.__init__` raises `AttributeError` on HA versions where `_attr_name` has no class-level default until it is explicitly set
- This crash occurs when multiple virtual interfaces map to the same AP device (e.g. mesh nodes like Linksys MX4300), triggering the disambiguation block added in the Multi-AP feature
- Because the exception propagates out of `_async_discover_entities` before `async_add_entities` is called, **all** accumulated sensors (system, storage, wifi, etc.) are silently discarded — the router shows no sensors at all
- Fix: use `getattr(self, '_attr_name', None)` so the read is safe regardless of HA version

Fixes #45

## Test plan

- [ ] Fresh setup on a router with multiple virtual interfaces mapping to the same AP (e.g. Linksys MX4300 mesh node) — sensors now appear
- [ ] Routers with a single interface per AP device unaffected (disambiguation block is skipped)
- [ ] `name_label` disambiguation still works correctly when the block is entered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where multiple virtual WiFi interfaces resolving to the same access point could cause errors when updating entity names on certain Home Assistant versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FaserF/ha-openwrt/pull/46)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->