### PR TITLE
fix(wireguard): parse the 'wg show all dump' interface layout

### DIFF
--- a/custom_components/openwrt/api/ubus/network.py
+++ b/custom_components/openwrt/api/ubus/network.py
@@ -402,7 +402,7 @@ class UbusNetworkMixin:
             iface_map: dict[str, WireGuardInterface] = {}
             for line in stdout.splitlines():
                 parts = line.split("\t")
-                if len(parts) == 4:
+                if len(parts) == 5:
                     # Interface line
                     ifname = parts[0]
                     if ifname not in wg_ifaces:
@@ -410,13 +410,13 @@ class UbusNetworkMixin:
                     iface = WireGuardInterface(
                         name=ifname,
                         enabled=wg_ifaces[ifname],
-                        public_key=parts[1],
-                        listen_port=int(parts[2]) if parts[2].isdigit() else 0,
-                        fwmark=int(parts[3]) if parts[3].isdigit() else 0,
+                        public_key=parts[2],
+                        listen_port=int(parts[3]) if parts[3].isdigit() else 0,
+                        fwmark=int(parts[4]) if parts[4].isdigit() else 0,
                     )
                     iface_map[ifname] = iface
                     interfaces.append(iface)
-                elif len(parts) >= 8:
+                elif len(parts) >= 9:
                     # Peer line
                     # Format: interface peer_public_key preshared_key endpoint allowed_ips latest_handshake transfer_rx transfer_tx persistent_keepalive
                     # Wait, 'wg show all dump' includes the interface name as the first part for peers too?

--- a/tests/test_api_wireguard.py
+++ b/tests/test_api_wireguard.py
@@ -32,17 +32,19 @@ async def test_ubus_get_wireguard_interfaces(ubus_client: UbusClient):
         mock_call.side_effect = [
             {
                 "interface": [
-                    {"interface": "wg0", "proto": "wireguard"},
+                    {"interface": "wg0", "proto": "wireguard", "up": True},
                     {"interface": "lan", "proto": "static"},
                 ]
             }
         ]
 
-        # 2. Mock wg show all dump
-        # Format: interface public_key listen_port fwmark
-        # Format: interface peer_public_key preshared_key endpoint allowed_ips latest_handshake transfer_rx transfer_tx persistent_keepalive
+        # 2. Mock `wg show all dump`. In `all` mode every line is prefixed with
+        # the interface name, so:
+        #   interface: iface private_key public_key listen_port fwmark   (5 cols)
+        #   peer:      iface public_key preshared_key endpoint allowed_ips
+        #              latest_handshake transfer_rx transfer_tx persistent_keepalive  (9 cols)
         mock_exec.return_value = (
-            "wg0\tPUBKEY_IFACE\t51820\t0\n"
+            "wg0\tPRIVKEY_IFACE\tPUBKEY_IFACE\t51820\t0\n"
             "wg0\tPUBKEY_PEER\t(none)\t1.2.3.4:5678\t10.0.0.2/32\t1624531234\t1024\t2048\t25\n"
         )
 
@@ -51,8 +53,11 @@ async def test_ubus_get_wireguard_interfaces(ubus_client: UbusClient):
         assert len(interfaces) == 1
         wg0 = interfaces[0]
         assert wg0.name == "wg0"
+        # public key is the 3rd column (after the private key), not the 2nd
         assert wg0.public_key == "PUBKEY_IFACE"
         assert wg0.listen_port == 51820
+        assert wg0.fwmark == 0
+        assert wg0.enabled is True
 
         assert len(wg0.peers) == 1
         peer = wg0.peers[0]
@@ -63,3 +68,35 @@ async def test_ubus_get_wireguard_interfaces(ubus_client: UbusClient):
         assert peer.transfer_rx == 1024
         assert peer.transfer_tx == 2048
         assert peer.persistent_keepalive == 25
+
+
+@pytest.mark.asyncio
+async def test_ubus_wireguard_none_values_and_unknown_iface(ubus_client: UbusClient):
+    """'(none)' endpoint/allowed-ips map to empty, a down interface is not
+    enabled, and peer lines for an unknown interface are ignored."""
+    with (
+        patch.object(ubus_client, "_call", new_callable=AsyncMock) as mock_call,
+        patch.object(
+            ubus_client, "execute_command", new_callable=AsyncMock
+        ) as mock_exec,
+    ):
+        mock_call.side_effect = [
+            {"interface": [{"interface": "wg0", "proto": "wireguard", "up": False}]}
+        ]
+        mock_exec.return_value = (
+            "wg0\tPRIVKEY\tPUBKEY0\t51820\t0\n"
+            "wg0\tPEER_A\t(none)\t(none)\t(none)\t0\t0\t0\t0\n"
+            # peer under an interface that is not a configured WG interface
+            "other\tPEER_B\t(none)\t9.9.9.9:1\t10.0.0.9/32\t0\t0\t0\t0\n"
+        )
+
+        interfaces = await ubus_client.get_wireguard_interfaces()
+
+        assert len(interfaces) == 1
+        wg0 = interfaces[0]
+        assert wg0.enabled is False
+        assert len(wg0.peers) == 1
+        peer = wg0.peers[0]
+        assert peer.public_key == "PEER_A"
+        assert peer.endpoint == ""
+        assert peer.allowed_ips == []


### PR DESCRIPTION
## Description

`get_wireguard_interfaces()` runs `wg show all dump` but parses the *single-interface* dump layout. In `all` mode, wireguard-tools prefixes every line with the interface name, so an interface line has **5** fields (`iface  private_key  public_key  listen_port  fwmark`) and a peer line has **9**. The parser matched on 4 fields and read the public key from the private-key column, so no `WireGuardInterface` was ever created and every peer was dropped — the WireGuard entities showed no data.

Fix: match 5 fields for the interface line, take the public key from the correct column, and require 9 fields for a peer line. The peer-field indices were already correct for the interface-prefixed layout. This is a 5-line change; no behaviour changes elsewhere.

The `wg show all dump` column layout is a stable wireguard-tools 1.0 contract, so it holds for OpenWrt 25.12 and newer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Tested on actual hardware (OpenWrt Version: **SNAPSHOT r35209**, wireguard-tools **v1.0.20260223**; Device: **ArmSoM Sige5, rockchip**)

Confirmed `wg show all dump` emits 5-column interface lines and 9-column peer lines, and the WireGuard interface/peer sensors now populate (public key, endpoint, allowed-IPs, transfer, handshake).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes

