### PR TITLE
feat(api): add read_file primitive

### DIFF
--- a/custom_components/openwrt/api/base.py
+++ b/custom_components/openwrt/api/base.py
@@ -1211,6 +1211,10 @@ class OpenWrtClient(abc.ABC):
         """Execute a binary via rpcd file.exec. Returns {} if unsupported by this client."""
         return {}
 
+    async def read_file(self, path: str) -> str | None:
+        """Read a file's contents. None if unsupported by this client or on error."""
+        return None
+
     async def kick_device(self, mac_address: str, interface: str) -> bool:
         """Kick a wireless device from the network using hostapd."""
         cmd_ubus = f'ubus call hostapd.{interface} del_client \'{{"addr":"{mac_address}","reason":5,"deauth":true,"ban_time":60000}}\''

--- a/custom_components/openwrt/api/luci_rpc/client.py
+++ b/custom_components/openwrt/api/luci_rpc/client.py
@@ -257,6 +257,13 @@ class LuciRpcClient(
             return {"code": rc or 1, "stdout": "", "stderr": stdout}
         return {"code": rc, "stdout": stdout, "stderr": ""}
 
+    async def read_file(self, path: str) -> str | None:
+        """Read a file via LuCI RPC (cat through sys.exec)."""
+        import shlex
+
+        out = await self.execute_command(f"cat {shlex.quote(path)} 2>/dev/null")
+        return out if out else None
+
     async def user_exists(self, username: str) -> bool:
         """Check if a system user exists on the device."""
         # 1. Try via LuCI RPC (often more restricted than ubus, but let's try reading passwd)

--- a/custom_components/openwrt/api/ssh/client.py
+++ b/custom_components/openwrt/api/ssh/client.py
@@ -154,6 +154,11 @@ class SshClient(
             return {"code": rc, "stdout": "", "stderr": stdout}
         return {"code": rc, "stdout": stdout, "stderr": ""}
 
+    async def read_file(self, path: str) -> str | None:
+        """Read a file over SSH via cat (SSH is inherently a shell session)."""
+        out = await self._exec(f"cat {shlex.quote(path)} 2>/dev/null")
+        return out if out else None
+
     async def provision_user(
         self,
         username: str,

--- a/custom_components/openwrt/api/ubus/system.py
+++ b/custom_components/openwrt/api/ubus/system.py
@@ -575,6 +575,16 @@ class UbusSystemMixin:
         except UbusError:
             raise
 
+    async def read_file(self, path: str) -> str | None:
+        """Read a file via rpcd file.read (needs only 'read' ACL on the path)."""
+        try:
+            res = await self._call("file", "read", {"path": path})
+            if isinstance(res, dict) and res.get("data") is not None:
+                return str(res["data"])
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("file.read failed for %s: %s", path, err)
+        return None
+
     async def user_exists(self, username: str) -> bool:
         """Check if a system user exists on the device."""
         # 1. Try via ubus file.read (more robust/standard than exec)

--- a/tests/test_api_read_file.py
+++ b/tests/test_api_read_file.py
@@ -1,0 +1,43 @@
+"""Tests for the read_file primitive."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.openwrt.api.ubus import UbusClient
+
+
+@pytest.fixture
+def ubus_client() -> UbusClient:
+    return UbusClient(
+        MagicMock(),
+        MagicMock(),
+        host="192.168.1.1",
+        username="root",
+        password="password",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ubus_read_file_returns_data(ubus_client: UbusClient):
+    """ubus read_file returns the file contents from rpcd file.read."""
+    with patch.object(ubus_client, "_call", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = {"data": "line1\nline2\n"}
+        assert await ubus_client.read_file("/proc/x") == "line1\nline2\n"
+        mock_call.assert_awaited_with("file", "read", {"path": "/proc/x"})
+
+
+@pytest.mark.asyncio
+async def test_ubus_read_file_missing_data_returns_none(ubus_client: UbusClient):
+    """A response without a 'data' field yields None."""
+    with patch.object(ubus_client, "_call", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = {}
+        assert await ubus_client.read_file("/proc/x") is None
+
+
+@pytest.mark.asyncio
+async def test_ubus_read_file_error_returns_none(ubus_client: UbusClient):
+    """A failing read (e.g. permission denied) yields None rather than raising."""
+    with patch.object(ubus_client, "_call", new_callable=AsyncMock) as mock_call:
+        mock_call.side_effect = Exception("access denied")
+        assert await ubus_client.read_file("/etc/shadow") is None


### PR DESCRIPTION
## Description

Adds `OpenWrtClient.read_file(path)` returning a file's contents, or `None` if the backend doesn't support it or on error. The ubus backend reads via rpcd `file.read` (needs only `read` permission on the path — no exec grant); the ssh and luci_rpc backends read via `cat` over their existing exec transport.

A small, additive primitive: a least-privilege way to read small config / `/proc` files without shelling out. No existing behaviour changes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Tested on actual hardware (OpenWrt Version: **SNAPSHOT r35209**; Device: **ArmSoM Sige5, rockchip**)

ubus `read_file` returns the contents of `/proc` and config paths via `file.read`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes

