### PR TITLE
feat(sensors): add connection-tracking (conntrack) sensor

### DIFF
--- a/custom_components/openwrt/api/base.py
+++ b/custom_components/openwrt/api/base.py
@@ -1211,6 +1211,10 @@ class OpenWrtClient(abc.ABC):
         """Execute a binary via rpcd file.exec. Returns {} if unsupported by this client."""
         return {}
 
+    async def read_file(self, path: str) -> str | None:
+        """Read a file's contents. None if unsupported by this client or on error."""
+        return None
+
     async def kick_device(self, mac_address: str, interface: str) -> bool:
         """Kick a wireless device from the network using hostapd."""
         cmd_ubus = f'ubus call hostapd.{interface} del_client \'{{"addr":"{mac_address}","reason":5,"deauth":true,"ban_time":60000}}\''

--- a/custom_components/openwrt/api/base.py
+++ b/custom_components/openwrt/api/base.py
@@ -68,7 +68,7 @@ echo "LOG: TRACE: Password set"
 
 ACL_FILE="/usr/share/rpcd/acl.d/homeassistant.json"
 mkdir -p "$(dirname "$ACL_FILE")"
-printf '{{\\n  "homeassistant": {{\\n    "description": "Home Assistant Integration",\\n    "read": {{\\n      "ubus": {{\\n        "system": ["info", "board", "logread", "upgrade"],\\n        "log": ["read"],\\n        "network": ["*"],\\n        "network.*": ["*"],\\n        "iwinfo": ["*"],\\n        "file": ["*"],\\n        "firewall": ["*"],\\n        "rc": ["*"],\\n        "service": ["*"],\\n        "system": ["*"],\\n        "uci": ["*"],\\n        "session": ["*"],\\n        "hostapd.*": ["*"],\\n        "luci": ["*"],\\n        "luci-rpc": ["*"],\\n        "attendedsysupgrade": ["*"]\\n      }},\\n      "uci": ["*"],\\n      "file": {{\\n        "/etc/config/*": ["read", "stat"],\\n        "/etc/passwd": ["read"],\\n        "/etc/group": ["read"],\\n        "/etc/shadow": ["read"],\\n        "/etc/shells": ["read"],\\n        "/usr/bin/iwinfo": ["read", "stat", "exec"],\\n        "/usr/bin/etherwake": ["read", "stat", "exec"],\\n        "/usr/bin/wg": ["read", "stat", "exec"],\\n        "/usr/sbin/openvpn": ["read", "stat", "exec"],\\n        "/usr/bin/id": ["read", "stat", "exec"],\\n        "/bin/sh": ["read", "stat", "exec"],\\n        "/bin/ash": ["read", "stat", "exec"],\\n        "/bin/ls": ["read", "stat", "exec"],\\n        "/sbin/apk": ["read", "stat", "exec"],\\n        "/bin/opkg": ["read", "stat", "exec"],\\n        "/sbin/logread": ["read", "stat"],\\n        "/etc/presence/*": ["read", "stat"],\\n        "/etc/init.d/presence_hostapd": ["read", "stat", "exec"],\\n        "/usr/sbin/batctl": ["read", "stat", "exec"],\\n        "/sys/module/batman_adv": ["read", "stat"],\\n        "/bin/cat": ["read", "stat", "exec"],\\n        "/bin/grep": ["read", "stat", "exec"],\\n        "/usr/bin/awk": ["read", "stat", "exec"],\\n        "/bin/df": ["read", "stat", "exec"],\\n        "/sbin/ip": ["read", "stat", "exec"],\\n        "/usr/sbin/ip": ["read", "stat", "exec"],\\n        "/bin/ubus": ["read", "stat", "exec"],\\n        "/bin/ping": ["read", "stat", "exec"],\\n        "/usr/bin/ping": ["read", "stat", "exec"],\\n        "/usr/bin/uptime": ["read", "stat", "exec"],\\n        "/usr/bin/killall": ["read", "stat", "exec"],\\n        "/bin/chmod": ["read", "stat", "exec"],\\n        "/bin/mkdir": ["read", "stat", "exec"],\\n        "/bin/rm": ["read", "stat", "exec"],\\n        "/proc/stat": ["read"],\\n        "/proc/meminfo": ["read"],\\n        "/proc/net/arp": ["read"],\\n        "/proc/net/dev": ["read"],\\n        "/tmp/dhcp.leases": ["read"],\\n        "/sys/class/thermal/*": ["read"]\\n      }}\\n    }},\\n    "write": {{\\n      "ubus": {{\\n        "system": ["reboot", "upgrade"],\\n        "network.interface": ["up", "down", "reconnect"],\\n        "network": ["*"],\\n        "firewall": ["*"],\\n        "rc": ["*"],\\n        "service": ["*"],\\n        "uci": ["*"],\\n        "file": ["exec"],\\n        "hostapd.*": ["*"]\\n      }},\\n      "uci": ["*"],\\n      "file": {{\\n        "/bin/sh": ["exec"],\\n        "/bin/ash": ["exec"],\\n        "/usr/bin/id": ["exec"],\\n        "/sbin/apk": ["exec"],\\n        "/bin/opkg": ["exec"],\\n        "/etc/presence/*": ["read", "stat", "write"],\\n        "/etc/init.d/presence_hostapd": ["read", "stat", "write", "exec"]\\n      }}\\n    }}\\n  }}\\n}}' > "$ACL_FILE"
+printf '{{\\n  "homeassistant": {{\\n    "description": "Home Assistant Integration",\\n    "read": {{\\n      "ubus": {{\\n        "system": ["info", "board", "logread", "upgrade"],\\n        "log": ["read"],\\n        "network": ["*"],\\n        "network.*": ["*"],\\n        "iwinfo": ["*"],\\n        "file": ["*"],\\n        "firewall": ["*"],\\n        "rc": ["*"],\\n        "service": ["*"],\\n        "system": ["*"],\\n        "uci": ["*"],\\n        "session": ["*"],\\n        "hostapd.*": ["*"],\\n        "luci": ["*"],\\n        "luci-rpc": ["*"],\\n        "attendedsysupgrade": ["*"]\\n      }},\\n      "uci": ["*"],\\n      "file": {{\\n        "/etc/config/*": ["read", "stat"],\\n        "/etc/passwd": ["read"],\\n        "/etc/group": ["read"],\\n        "/etc/shadow": ["read"],\\n        "/etc/shells": ["read"],\\n        "/usr/bin/iwinfo": ["read", "stat", "exec"],\\n        "/usr/bin/etherwake": ["read", "stat", "exec"],\\n        "/usr/bin/wg": ["read", "stat", "exec"],\\n        "/usr/sbin/openvpn": ["read", "stat", "exec"],\\n        "/usr/bin/id": ["read", "stat", "exec"],\\n        "/bin/sh": ["read", "stat", "exec"],\\n        "/bin/ash": ["read", "stat", "exec"],\\n        "/bin/ls": ["read", "stat", "exec"],\\n        "/sbin/apk": ["read", "stat", "exec"],\\n        "/bin/opkg": ["read", "stat", "exec"],\\n        "/sbin/logread": ["read", "stat"],\\n        "/etc/presence/*": ["read", "stat"],\\n        "/etc/init.d/presence_hostapd": ["read", "stat", "exec"],\\n        "/usr/sbin/batctl": ["read", "stat", "exec"],\\n        "/sys/module/batman_adv": ["read", "stat"],\\n        "/bin/cat": ["read", "stat", "exec"],\\n        "/bin/grep": ["read", "stat", "exec"],\\n        "/usr/bin/awk": ["read", "stat", "exec"],\\n        "/bin/df": ["read", "stat", "exec"],\\n        "/sbin/ip": ["read", "stat", "exec"],\\n        "/usr/sbin/ip": ["read", "stat", "exec"],\\n        "/bin/ubus": ["read", "stat", "exec"],\\n        "/bin/ping": ["read", "stat", "exec"],\\n        "/usr/bin/ping": ["read", "stat", "exec"],\\n        "/usr/bin/uptime": ["read", "stat", "exec"],\\n        "/usr/bin/killall": ["read", "stat", "exec"],\\n        "/bin/chmod": ["read", "stat", "exec"],\\n        "/bin/mkdir": ["read", "stat", "exec"],\\n        "/bin/rm": ["read", "stat", "exec"],\\n        "/proc/stat": ["read"],\\n        "/proc/meminfo": ["read"],\\n        "/proc/net/arp": ["read"],\\n        "/proc/net/dev": ["read"],\\n        "/proc/sys/net/netfilter/nf_conntrack_count": ["read"],\\n        "/proc/sys/net/netfilter/nf_conntrack_max": ["read"],\\n        "/tmp/dhcp.leases": ["read"],\\n        "/sys/class/thermal/*": ["read"]\\n      }}\\n    }},\\n    "write": {{\\n      "ubus": {{\\n        "system": ["reboot", "upgrade"],\\n        "network.interface": ["up", "down", "reconnect"],\\n        "network": ["*"],\\n        "firewall": ["*"],\\n        "rc": ["*"],\\n        "service": ["*"],\\n        "uci": ["*"],\\n        "file": ["exec"],\\n        "hostapd.*": ["*"]\\n      }},\\n      "uci": ["*"],\\n      "file": {{\\n        "/bin/sh": ["exec"],\\n        "/bin/ash": ["exec"],\\n        "/usr/bin/id": ["exec"],\\n        "/sbin/apk": ["exec"],\\n        "/bin/opkg": ["exec"],\\n        "/etc/presence/*": ["read", "stat", "write"],\\n        "/etc/init.d/presence_hostapd": ["read", "stat", "write", "exec"]\\n      }}\\n    }}\\n  }}\\n}}' > "$ACL_FILE"
 chmod 644 "$ACL_FILE"
 echo "LOG: TRACE: ACL created"
 
@@ -315,6 +315,8 @@ class SystemResources:
     load_15min: float = 0.0
     uptime: int = 0
     processes: int = 0
+    conntrack_count: int = 0
+    conntrack_max: int = 0
     temperature: float | None = None
     temperatures: dict[str, float] = field(default_factory=dict)
     cpu_frequency: float | None = None
@@ -1215,6 +1217,19 @@ class OpenWrtClient(abc.ABC):
         """Read a file's contents. None if unsupported by this client or on error."""
         return None
 
+    async def _fetch_conntrack(self, resources: SystemResources) -> None:
+        """Populate nf_conntrack count/max from /proc."""
+        for attr, path in (
+            ("conntrack_count", "/proc/sys/net/netfilter/nf_conntrack_count"),
+            ("conntrack_max", "/proc/sys/net/netfilter/nf_conntrack_max"),
+        ):
+            data = await self.read_file(path)
+            if not data:
+                continue
+            match = re.search(r"\d+", data)
+            if match:
+                setattr(resources, attr, int(match.group(0)))
+
     async def kick_device(self, mac_address: str, interface: str) -> bool:
         """Kick a wireless device from the network using hostapd."""
         cmd_ubus = f'ubus call hostapd.{interface} del_client \'{{"addr":"{mac_address}","reason":5,"deauth":true,"ban_time":60000}}\''
@@ -1885,6 +1900,7 @@ class OpenWrtClient(abc.ABC):
         data.system_resources = get_val(
             core_results[0], data.system_resources, "system_resources"
         )
+        await self._fetch_conntrack(data.system_resources)
         data.network_interfaces = get_val(
             core_results[1], data.network_interfaces, "network_interfaces"
         )

--- a/custom_components/openwrt/api/luci_rpc/client.py
+++ b/custom_components/openwrt/api/luci_rpc/client.py
@@ -257,6 +257,13 @@ class LuciRpcClient(
             return {"code": rc or 1, "stdout": "", "stderr": stdout}
         return {"code": rc, "stdout": stdout, "stderr": ""}
 
+    async def read_file(self, path: str) -> str | None:
+        """Read a file via LuCI RPC (cat through sys.exec)."""
+        import shlex
+
+        out = await self.execute_command(f"cat {shlex.quote(path)} 2>/dev/null")
+        return out if out else None
+
     async def user_exists(self, username: str) -> bool:
         """Check if a system user exists on the device."""
         # 1. Try via LuCI RPC (often more restricted than ubus, but let's try reading passwd)

--- a/custom_components/openwrt/api/ssh/client.py
+++ b/custom_components/openwrt/api/ssh/client.py
@@ -154,6 +154,11 @@ class SshClient(
             return {"code": rc, "stdout": "", "stderr": stdout}
         return {"code": rc, "stdout": stdout, "stderr": ""}
 
+    async def read_file(self, path: str) -> str | None:
+        """Read a file over SSH via cat (SSH is inherently a shell session)."""
+        out = await self._exec(f"cat {shlex.quote(path)} 2>/dev/null")
+        return out if out else None
+
     async def provision_user(
         self,
         username: str,

--- a/custom_components/openwrt/api/ubus/system.py
+++ b/custom_components/openwrt/api/ubus/system.py
@@ -575,6 +575,16 @@ class UbusSystemMixin:
         except UbusError:
             raise
 
+    async def read_file(self, path: str) -> str | None:
+        """Read a file via rpcd file.read (needs only 'read' ACL on the path)."""
+        try:
+            res = await self._call("file", "read", {"path": path})
+            if isinstance(res, dict) and res.get("data") is not None:
+                return str(res["data"])
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("file.read failed for %s: %s", path, err)
+        return None
+
     async def user_exists(self, username: str) -> bool:
         """Check if a system user exists on the device."""
         # 1. Try via ubus file.read (more robust/standard than exec)

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -475,6 +475,31 @@ def _get_system_sensors() -> tuple[OpenWrtSensorDescription, ...]:
             value_fn=lambda data: round(data.system_resources.load_15min, 2),
         ),
         OpenWrtSensorDescription(
+            key="conntrack_count",
+            name="Connection Tracking",
+            translation_key="conntrack_count",
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_registry_enabled_default=False,
+            icon="mdi:table-network",
+            native_unit_of_measurement="connections",
+            value_fn=lambda data: data.system_resources.conntrack_count,
+            available_fn=lambda data: data.system_resources.conntrack_max > 0,
+            attrs_fn=lambda data: {
+                "max": data.system_resources.conntrack_max,
+                "usage_percent": (
+                    round(
+                        data.system_resources.conntrack_count
+                        / data.system_resources.conntrack_max
+                        * 100.0,
+                        1,
+                    )
+                    if data.system_resources.conntrack_max > 0
+                    else None
+                ),
+            },
+        ),
+        OpenWrtSensorDescription(
             key="uptime",
             name="Uptime",
             translation_key="uptime",

--- a/custom_components/openwrt/strings.json
+++ b/custom_components/openwrt/strings.json
@@ -410,6 +410,9 @@
       "load_1min": {
         "name": "Load (1m)"
       },
+      "conntrack_count": {
+        "name": "Connection Tracking"
+      },
       "load_5min": {
         "name": "Load (5m)"
       },

--- a/custom_components/openwrt/translations/de.json
+++ b/custom_components/openwrt/translations/de.json
@@ -410,6 +410,9 @@
       "load_1min": {
         "name": "Systemlast (1m)"
       },
+      "conntrack_count": {
+        "name": "Verbindungsverfolgung"
+      },
       "load_5min": {
         "name": "Systemlast (5m)"
       },

--- a/custom_components/openwrt/translations/en.json
+++ b/custom_components/openwrt/translations/en.json
@@ -410,6 +410,9 @@
       "load_1min": {
         "name": "Load (1m)"
       },
+      "conntrack_count": {
+        "name": "Connection Tracking"
+      },
       "load_5min": {
         "name": "Load (5m)"
       },

--- a/tests/test_api_read_file.py
+++ b/tests/test_api_read_file.py
@@ -1,0 +1,43 @@
+"""Tests for the read_file primitive."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.openwrt.api.ubus import UbusClient
+
+
+@pytest.fixture
+def ubus_client() -> UbusClient:
+    return UbusClient(
+        MagicMock(),
+        MagicMock(),
+        host="192.168.1.1",
+        username="root",
+        password="password",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ubus_read_file_returns_data(ubus_client: UbusClient):
+    """ubus read_file returns the file contents from rpcd file.read."""
+    with patch.object(ubus_client, "_call", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = {"data": "line1\nline2\n"}
+        assert await ubus_client.read_file("/proc/x") == "line1\nline2\n"
+        mock_call.assert_awaited_with("file", "read", {"path": "/proc/x"})
+
+
+@pytest.mark.asyncio
+async def test_ubus_read_file_missing_data_returns_none(ubus_client: UbusClient):
+    """A response without a 'data' field yields None."""
+    with patch.object(ubus_client, "_call", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = {}
+        assert await ubus_client.read_file("/proc/x") is None
+
+
+@pytest.mark.asyncio
+async def test_ubus_read_file_error_returns_none(ubus_client: UbusClient):
+    """A failing read (e.g. permission denied) yields None rather than raising."""
+    with patch.object(ubus_client, "_call", new_callable=AsyncMock) as mock_call:
+        mock_call.side_effect = Exception("access denied")
+        assert await ubus_client.read_file("/etc/shadow") is None

--- a/tests/test_conntrack.py
+++ b/tests/test_conntrack.py
@@ -1,0 +1,50 @@
+"""Tests for connection-tracking (conntrack) metric collection."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.openwrt.api.base import SystemResources
+from custom_components.openwrt.api.ubus import UbusClient
+
+
+@pytest.fixture
+def ubus_client() -> UbusClient:
+    return UbusClient(
+        MagicMock(),
+        MagicMock(),
+        host="192.168.1.1",
+        username="root",
+        password="password",
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_conntrack_populates(ubus_client: UbusClient):
+    """count/max are parsed from the two /proc entries via read_file."""
+    res = SystemResources()
+
+    async def fake_read(path: str):
+        if path.endswith("nf_conntrack_count"):
+            return "256\n"
+        if path.endswith("nf_conntrack_max"):
+            return "262144\n"
+        return None
+
+    with patch.object(ubus_client, "read_file", side_effect=fake_read):
+        await ubus_client._fetch_conntrack(res)
+
+    assert res.conntrack_count == 256
+    assert res.conntrack_max == 262144
+
+
+@pytest.mark.asyncio
+async def test_fetch_conntrack_missing_stays_zero(ubus_client: UbusClient):
+    """If the reads fail/return nothing, the counters stay at 0."""
+    res = SystemResources()
+    with patch.object(ubus_client, "read_file", new_callable=AsyncMock) as mock_read:
+        mock_read.return_value = None
+        await ubus_client._fetch_conntrack(res)
+
+    assert res.conntrack_count == 0
+    assert res.conntrack_max == 0


### PR DESCRIPTION
## Description

Adds a "Connection Tracking" sensor (disabled by default) reporting the current nf_conntrack entry count from `/proc/sys/net/netfilter/nf_conntrack_count`, with `nf_conntrack_max` and a usage-percent as attributes. It is fetched in the backend-agnostic client pipeline via `read_file`, so it works across ubus/ssh/luci_rpc; the ubus path needs only `read` permission on the two `/proc` paths (no exec grant).

> Depends on #83 (adds `read_file`). Until that merges, this PR's diff also shows the `read_file` commit; it drops out once #83 lands in `main`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Tested on actual hardware (OpenWrt Version: **SNAPSHOT r35209**; Device: **ArmSoM Sige5, rockchip**)

Sensor reports the live conntrack count with max + usage-percent attributes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes

