### PR TITLE
feat(banip): banIP status + packet-block counters

### DIFF
--- a/custom_components/openwrt/api/base.py
+++ b/custom_components/openwrt/api/base.py
@@ -68,7 +68,7 @@ echo "LOG: TRACE: Password set"
 
 ACL_FILE="/usr/share/rpcd/acl.d/homeassistant.json"
 mkdir -p "$(dirname "$ACL_FILE")"
-printf '{{\\n  "homeassistant": {{\\n    "description": "Home Assistant Integration",\\n    "read": {{\\n      "ubus": {{\\n        "system": ["info", "board", "logread", "upgrade"],\\n        "log": ["read"],\\n        "network": ["*"],\\n        "network.*": ["*"],\\n        "iwinfo": ["*"],\\n        "file": ["*"],\\n        "firewall": ["*"],\\n        "rc": ["*"],\\n        "service": ["*"],\\n        "system": ["*"],\\n        "uci": ["*"],\\n        "session": ["*"],\\n        "hostapd.*": ["*"],\\n        "luci": ["*"],\\n        "luci-rpc": ["*"],\\n        "attendedsysupgrade": ["*"]\\n      }},\\n      "uci": ["*"],\\n      "file": {{\\n        "/etc/config/*": ["read", "stat"],\\n        "/etc/passwd": ["read"],\\n        "/etc/group": ["read"],\\n        "/etc/shadow": ["read"],\\n        "/etc/shells": ["read"],\\n        "/usr/bin/iwinfo": ["read", "stat", "exec"],\\n        "/usr/bin/etherwake": ["read", "stat", "exec"],\\n        "/usr/bin/wg": ["read", "stat", "exec"],\\n        "/usr/sbin/openvpn": ["read", "stat", "exec"],\\n        "/usr/bin/id": ["read", "stat", "exec"],\\n        "/bin/sh": ["read", "stat", "exec"],\\n        "/bin/ash": ["read", "stat", "exec"],\\n        "/bin/ls": ["read", "stat", "exec"],\\n        "/sbin/apk": ["read", "stat", "exec"],\\n        "/bin/opkg": ["read", "stat", "exec"],\\n        "/sbin/logread": ["read", "stat"],\\n        "/etc/presence/*": ["read", "stat"],\\n        "/etc/init.d/presence_hostapd": ["read", "stat", "exec"],\\n        "/usr/sbin/batctl": ["read", "stat", "exec"],\\n        "/sys/module/batman_adv": ["read", "stat"],\\n        "/bin/cat": ["read", "stat", "exec"],\\n        "/bin/grep": ["read", "stat", "exec"],\\n        "/usr/bin/awk": ["read", "stat", "exec"],\\n        "/bin/df": ["read", "stat", "exec"],\\n        "/sbin/ip": ["read", "stat", "exec"],\\n        "/usr/sbin/ip": ["read", "stat", "exec"],\\n        "/bin/ubus": ["read", "stat", "exec"],\\n        "/bin/ping": ["read", "stat", "exec"],\\n        "/usr/bin/ping": ["read", "stat", "exec"],\\n        "/usr/bin/uptime": ["read", "stat", "exec"],\\n        "/usr/bin/killall": ["read", "stat", "exec"],\\n        "/bin/chmod": ["read", "stat", "exec"],\\n        "/bin/mkdir": ["read", "stat", "exec"],\\n        "/bin/rm": ["read", "stat", "exec"],\\n        "/proc/stat": ["read"],\\n        "/proc/meminfo": ["read"],\\n        "/proc/net/arp": ["read"],\\n        "/proc/net/dev": ["read"],\\n        "/tmp/dhcp.leases": ["read"],\\n        "/sys/class/thermal/*": ["read"]\\n      }}\\n    }},\\n    "write": {{\\n      "ubus": {{\\n        "system": ["reboot", "upgrade"],\\n        "network.interface": ["up", "down", "reconnect"],\\n        "network": ["*"],\\n        "firewall": ["*"],\\n        "rc": ["*"],\\n        "service": ["*"],\\n        "uci": ["*"],\\n        "file": ["exec"],\\n        "hostapd.*": ["*"]\\n      }},\\n      "uci": ["*"],\\n      "file": {{\\n        "/bin/sh": ["exec"],\\n        "/bin/ash": ["exec"],\\n        "/usr/bin/id": ["exec"],\\n        "/sbin/apk": ["exec"],\\n        "/bin/opkg": ["exec"],\\n        "/etc/presence/*": ["read", "stat", "write"],\\n        "/etc/init.d/presence_hostapd": ["read", "stat", "write", "exec"]\\n      }}\\n    }}\\n  }}\\n}}' > "$ACL_FILE"
+printf '{{\\n  "homeassistant": {{\\n    "description": "Home Assistant Integration",\\n    "read": {{\\n      "ubus": {{\\n        "system": ["info", "board", "logread", "upgrade"],\\n        "log": ["read"],\\n        "network": ["*"],\\n        "network.*": ["*"],\\n        "iwinfo": ["*"],\\n        "file": ["*"],\\n        "firewall": ["*"],\\n        "rc": ["*"],\\n        "service": ["*"],\\n        "system": ["*"],\\n        "uci": ["*"],\\n        "session": ["*"],\\n        "hostapd.*": ["*"],\\n        "luci": ["*"],\\n        "luci-rpc": ["*"],\\n        "attendedsysupgrade": ["*"]\\n      }},\\n      "uci": ["*"],\\n      "file": {{\\n        "/etc/config/*": ["read", "stat"],\\n        "/etc/passwd": ["read"],\\n        "/etc/group": ["read"],\\n        "/etc/shadow": ["read"],\\n        "/etc/shells": ["read"],\\n        "/usr/bin/iwinfo": ["read", "stat", "exec"],\\n        "/usr/bin/etherwake": ["read", "stat", "exec"],\\n        "/usr/bin/wg": ["read", "stat", "exec"],\\n        "/usr/sbin/openvpn": ["read", "stat", "exec"],\\n        "/usr/bin/id": ["read", "stat", "exec"],\\n        "/bin/sh": ["read", "stat", "exec"],\\n        "/bin/ash": ["read", "stat", "exec"],\\n        "/bin/ls": ["read", "stat", "exec"],\\n        "/sbin/apk": ["read", "stat", "exec"],\\n        "/bin/opkg": ["read", "stat", "exec"],\\n        "/sbin/logread": ["read", "stat"],\\n        "/etc/presence/*": ["read", "stat"],\\n        "/etc/init.d/presence_hostapd": ["read", "stat", "exec"],\\n        "/usr/sbin/batctl": ["read", "stat", "exec"],\\n        "/sys/module/batman_adv": ["read", "stat"],\\n        "/bin/cat": ["read", "stat", "exec"],\\n        "/bin/grep": ["read", "stat", "exec"],\\n        "/usr/bin/awk": ["read", "stat", "exec"],\\n        "/bin/df": ["read", "stat", "exec"],\\n        "/sbin/ip": ["read", "stat", "exec"],\\n        "/usr/sbin/ip": ["read", "stat", "exec"],\\n        "/bin/ubus": ["read", "stat", "exec"],\\n        "/bin/ping": ["read", "stat", "exec"],\\n        "/usr/bin/ping": ["read", "stat", "exec"],\\n        "/usr/bin/uptime": ["read", "stat", "exec"],\\n        "/usr/bin/killall": ["read", "stat", "exec"],\\n        "/bin/chmod": ["read", "stat", "exec"],\\n        "/bin/mkdir": ["read", "stat", "exec"],\\n        "/bin/rm": ["read", "stat", "exec"],\\n        "/proc/stat": ["read"],\\n        "/proc/meminfo": ["read"],\\n        "/proc/net/arp": ["read"],\\n        "/proc/net/dev": ["read"],\\n        "/etc/init.d/banip": ["read", "stat", "exec"],\\n        "/tmp/dhcp.leases": ["read"],\\n        "/sys/class/thermal/*": ["read"]\\n      }}\\n    }},\\n    "write": {{\\n      "ubus": {{\\n        "system": ["reboot", "upgrade"],\\n        "network.interface": ["up", "down", "reconnect"],\\n        "network": ["*"],\\n        "firewall": ["*"],\\n        "rc": ["*"],\\n        "service": ["*"],\\n        "uci": ["*"],\\n        "file": ["exec"],\\n        "hostapd.*": ["*"]\\n      }},\\n      "uci": ["*"],\\n      "file": {{\\n        "/bin/sh": ["exec"],\\n        "/bin/ash": ["exec"],\\n        "/usr/bin/id": ["exec"],\\n        "/sbin/apk": ["exec"],\\n        "/bin/opkg": ["exec"],\\n        "/etc/presence/*": ["read", "stat", "write"],\\n        "/etc/init.d/presence_hostapd": ["read", "stat", "write", "exec"]\\n      }}\\n    }}\\n  }}\\n}}' > "$ACL_FILE"
 chmod 644 "$ACL_FILE"
 echo "LOG: TRACE: ACL created"
 
@@ -514,6 +514,10 @@ class BanIpStatus:
     status: str = "disabled"
     version: str | None = None
     banned_ips: int = 0
+    blocked_packets: int = 0
+    blocked_inbound: int = 0
+    blocked_outbound: int = 0
+    block_stats: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
@@ -1631,12 +1635,73 @@ class OpenWrtClient(abc.ABC):
         return False
 
     async def get_banip_status(self) -> BanIpStatus:
-        """Get status of the ban-ip package."""
-        return BanIpStatus()
+        """Get banIP status and runtime block counters."""
+        status = BanIpStatus()
+
+        try:
+            res = await self.file_exec("/etc/init.d/banip", ["enabled"])
+            if isinstance(res, dict) and "code" in res:
+                status.enabled = res.get("code") == 0
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("banip enabled probe failed: %s", err)
+        status.status = "enabled" if status.enabled else "disabled"
+
+        # Element count + packet-block counters from banIP's JSON report.
+        try:
+            res = await self.file_exec("/etc/init.d/banip", ["report", "json"])
+            out = res.get("stdout", "") if isinstance(res, dict) else ""
+            if out:
+                payload = json.loads(out)
+                summary = (
+                    payload[0]
+                    if isinstance(payload, list) and payload
+                    else payload
+                )
+                if isinstance(summary, dict):
+
+                    def _n(key: str) -> int:
+                        try:
+                            return int(str(summary.get(key, "0")).strip() or "0")
+                        except (ValueError, TypeError):
+                            return 0
+
+                    status.banned_ips = _n("sum_cntelements")
+                    status.blocked_inbound = _n("sum_setinbound")
+                    status.blocked_outbound = _n("sum_setoutbound")
+                    status.block_stats = {
+                        "inbound": status.blocked_inbound,
+                        "outbound": status.blocked_outbound,
+                        "syn_flood": _n("sum_synflood"),
+                        "udp_flood": _n("sum_udpflood"),
+                        "icmp_flood": _n("sum_icmpflood"),
+                        "ct_invalid": _n("sum_ctinvalid"),
+                        "tcp_invalid": _n("sum_tcpinvalid"),
+                        "bcp38": _n("sum_bcp38"),
+                        "autoadd_block": _n("autoadd_block"),
+                    }
+                    status.blocked_packets = sum(
+                        v
+                        for k, v in status.block_stats.items()
+                        if k != "autoadd_block"
+                    )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("banip report failed: %s", err)
+        return status
 
     async def set_banip_enabled(self, enabled: bool) -> bool:
-        """Enable/disable the ban-ip service."""
-        return False
+        """Enable/disable the banIP service (uci flag + init start/stop)."""
+        val = "1" if enabled else "0"
+        try:
+            await self.execute_command(
+                f"uci set banip.global.ban_enabled='{val}' && uci commit banip"
+            )
+            await self.execute_command(
+                f"/etc/init.d/banip {'start' if enabled else 'stop'}"
+            )
+            return True
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("banip enable/disable failed: %s", err)
+            return False
 
     async def get_latency(self, target: str = "8.8.8.8") -> LatencyResult | None:
         """Measure network latency via ping."""

--- a/custom_components/openwrt/api/luci_rpc/features.py
+++ b/custom_components/openwrt/api/luci_rpc/features.py
@@ -8,7 +8,6 @@ from typing import Any
 from ..base import (
     AccessControl,
     AdBlockStatus,
-    BanIpStatus,
     FirewallRedirect,
     FirewallRule,
     LedInfo,
@@ -422,38 +421,7 @@ class LuciRpcFeaturesMixin:
         except Exception:
             return False
 
-    async def get_banip_status(self) -> BanIpStatus:
-        """Get ban-ip status via LuCI RPC."""
-        from ..base import BanIpStatus
-
-        status = BanIpStatus()
-        try:
-            res = await self._rpc_call(
-                "sys",
-                "exec",
-                ["uci -q get ban-ip.config.enabled"],
-            )
-            status.enabled = res.strip() == "1"
-            status.status = "enabled" if status.enabled else "disabled"
-        except Exception:
-            pass
-        return status
-
-    async def set_banip_enabled(self, enabled: bool) -> bool:
-        """Enable/disable ban-ip service via LuCI RPC."""
-        val = "1" if enabled else "0"
-        try:
-            await self._rpc_call(
-                "sys",
-                "exec",
-                [f"uci set ban-ip.config.enabled='{val}' && uci commit ban-ip"],
-            )
-            action = "start" if enabled else "stop"
-            await self._rpc_call("sys", "exec", [f"/etc/init.d/ban-ip {action}"])
-            self._last_full_poll = 0
-            return True
-        except Exception:
-            return False
+    # banIP is handled backend-agnostically in OpenWrtClient (base.py).
 
     async def get_sqm_status(self) -> list[SqmStatus]:
         """Get SQM status via LuCI RPC."""

--- a/custom_components/openwrt/api/ssh/features.py
+++ b/custom_components/openwrt/api/ssh/features.py
@@ -9,7 +9,6 @@ from typing import Any
 from ..base import (
     AccessControl,
     AdBlockStatus,
-    BanIpStatus,
     FirewallRedirect,
     FirewallRule,
     NlbwmonTraffic,
@@ -525,31 +524,7 @@ class SshFeaturesMixin:
         except Exception:
             return False
 
-    async def get_banip_status(self) -> BanIpStatus:
-        """Get ban-ip status via SSH."""
-        from ..base import BanIpStatus
-
-        status = BanIpStatus()
-        try:
-            res = await self._exec("uci -q get ban-ip.config.enabled")
-            status.enabled = res.strip() == "1"
-            status.status = "enabled" if status.enabled else "disabled"
-        except Exception:
-            pass
-        return status
-
-    async def set_banip_enabled(self, enabled: bool) -> bool:
-        """Enable/disable ban-ip service via SSH."""
-        val = "1" if enabled else "0"
-        try:
-            safe_val = shlex.quote(f"ban-ip.config.enabled={val}")
-            await self._exec(f"uci set {safe_val} && uci commit ban-ip")
-            action = "start" if enabled else "stop"
-            await self._exec(f"/etc/init.d/ban-ip {action}")
-            self._last_full_poll = 0
-            return True
-        except Exception:
-            return False
+    # banIP is handled backend-agnostically in OpenWrtClient (base.py).
 
     async def get_sqm_status(self) -> list[SqmStatus]:
         """Get SQM status via SSH."""

--- a/custom_components/openwrt/api/ubus/features.py
+++ b/custom_components/openwrt/api/ubus/features.py
@@ -7,7 +7,6 @@ from typing import Any
 from ..base import (
     AccessControl,
     AdBlockStatus,
-    BanIpStatus,
     FirewallRedirect,
     FirewallRule,
     NlbwmonTraffic,
@@ -311,32 +310,8 @@ class UbusFeaturesMixin:
         except Exception:
             return False
 
-    async def get_banip_status(self) -> BanIpStatus:
-        """Get ban-ip status."""
-        from ..base import BanIpStatus
-
-        status = BanIpStatus()
-        try:
-            res = await self.execute_command("uci -q get ban-ip.config.enabled")
-            status.enabled = res.strip() == "1"
-            status.status = "enabled" if status.enabled else "disabled"
-        except Exception:
-            pass
-        return status
-
-    async def set_banip_enabled(self, enabled: bool) -> bool:
-        """Enable/disable ban-ip service."""
-        val = "1" if enabled else "0"
-        try:
-            await self.execute_command(
-                f"uci set ban-ip.config.enabled='{val}' && uci commit ban-ip",
-            )
-            action = "start" if enabled else "stop"
-            await self.execute_command(f"/etc/init.d/ban-ip {action}")
-            self._last_full_poll = 0
-            return True
-        except Exception:
-            return False
+    # banIP status/report + enable/disable are implemented backend-agnostically
+    # in OpenWrtClient.get_banip_status / set_banip_enabled (base.py).
 
     async def get_sqm_status(self) -> list[SqmStatus]:
         """Get SQM status via uci ubus."""

--- a/custom_components/openwrt/api/ubus/services.py
+++ b/custom_components/openwrt/api/ubus/services.py
@@ -285,7 +285,7 @@ class UbusServicesMixin:
                     "/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json "
                     "/etc/init.d/adblock "
                     "/etc/init.d/simple-adblock "
-                    "/etc/init.d/ban-ip "
+                    "/etc/init.d/banip "
                     "/etc/init.d/miniupnpd "
                     "/etc/init.d/nlbwmon "
                     "/etc/init.d/pbr "
@@ -426,7 +426,7 @@ class UbusServicesMixin:
             ("/usr/lib/lua/luci/controller/attendedsysupgrade.lua", "asu"),
             ("/etc/init.d/adblock", "adblock"),
             ("/etc/init.d/simple-adblock", "simple_adblock"),
-            ("/etc/init.d/ban-ip", "ban_ip"),
+            ("/etc/init.d/banip", "ban_ip"),
         ]
         for path, attr in check_list:
             if getattr(packages, attr) is not True:
@@ -452,7 +452,7 @@ class UbusServicesMixin:
             "asu": "luci-app-attendedsysupgrade",
             "adblock": "adblock",
             "simple_adblock": "simple-adblock",
-            "ban_ip": "ban-ip",
+            "ban_ip": "banip",
         }
         for attr, pkg_name in mapping.items():
             if getattr(packages, attr) is not True:

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -942,6 +942,17 @@ def _get_banip_sensors() -> tuple[OpenWrtSensorDescription, ...]:
             entity_category=EntityCategory.DIAGNOSTIC,
             value_fn=lambda data: data.ban_ip.banned_ips,
         ),
+        OpenWrtSensorDescription(
+            key="banip_blocked",
+            name="Ban-IP Blocked Packets",
+            translation_key="banip_blocked",
+            icon="mdi:shield-remove-outline",
+            native_unit_of_measurement="packets",
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            value_fn=lambda data: data.ban_ip.blocked_packets,
+            attrs_fn=lambda data: data.ban_ip.block_stats,
+        ),
     )
 
 

--- a/custom_components/openwrt/strings.json
+++ b/custom_components/openwrt/strings.json
@@ -464,6 +464,9 @@
       "banip_banned": {
         "name": "Ban-IP Banned IPs"
       },
+      "banip_blocked": {
+        "name": "Ban-IP Blocked Packets"
+      },
       "connected_clients": {
         "name": "Connected Clients"
       },

--- a/custom_components/openwrt/translations/de.json
+++ b/custom_components/openwrt/translations/de.json
@@ -464,6 +464,9 @@
       "banip_banned": {
         "name": "Ban-IP Gebannte IPs"
       },
+      "banip_blocked": {
+        "name": "Ban-IP blockierte Pakete"
+      },
       "connected_clients": {
         "name": "Verbundene Clients"
       },

--- a/custom_components/openwrt/translations/en.json
+++ b/custom_components/openwrt/translations/en.json
@@ -464,6 +464,9 @@
       "banip_banned": {
         "name": "Ban-IP Banned IPs"
       },
+      "banip_blocked": {
+        "name": "Ban-IP Blocked Packets"
+      },
       "connected_clients": {
         "name": "Connected Clients"
       },

--- a/tests/test_banip.py
+++ b/tests/test_banip.py
@@ -1,0 +1,65 @@
+"""Tests for banIP status + packet-block counter parsing."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.openwrt.api.ubus import UbusClient
+
+_REPORT = (
+    '[{"sets":{},"timestamp":"t",'
+    '"sum_synflood":"0","sum_udpflood":"0","sum_icmpflood":"2","sum_ctinvalid":"47",'
+    '"sum_tcpinvalid":"0","sum_bcp38":"0","sum_setinbound":"5","sum_setoutbound":"3",'
+    '"sum_cntelements":"19111","autoadd_block":"1"}]'
+)
+
+
+@pytest.fixture
+def ubus_client() -> UbusClient:
+    return UbusClient(
+        MagicMock(),
+        MagicMock(),
+        host="192.168.1.1",
+        username="root",
+        password="password",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_banip_status_parses_report(ubus_client: UbusClient):
+    async def fake_exec(command, params=None):
+        if params == ["enabled"]:
+            return {"code": 0}
+        if params == ["report", "json"]:
+            return {"code": 0, "stdout": _REPORT}
+        return {}
+
+    with patch.object(ubus_client, "file_exec", side_effect=fake_exec):
+        st = await ubus_client.get_banip_status()
+
+    assert st.enabled is True
+    assert st.status == "enabled"
+    assert st.banned_ips == 19111
+    assert st.blocked_inbound == 5
+    assert st.blocked_outbound == 3
+    assert st.block_stats["ct_invalid"] == 47
+    assert st.block_stats["icmp_flood"] == 2
+    assert st.block_stats["autoadd_block"] == 1
+    # total blocked packets excludes the autoadd bookkeeping counter
+    assert st.blocked_packets == 5 + 3 + 0 + 0 + 2 + 47 + 0 + 0
+
+
+@pytest.mark.asyncio
+async def test_get_banip_status_disabled_empty_report(ubus_client: UbusClient):
+    async def fake_exec(command, params=None):
+        if params == ["enabled"]:
+            return {"code": 1}
+        return {"code": 0, "stdout": "[]"}
+
+    with patch.object(ubus_client, "file_exec", side_effect=fake_exec):
+        st = await ubus_client.get_banip_status()
+
+    assert st.enabled is False
+    assert st.status == "disabled"
+    assert st.banned_ips == 0
+    assert st.blocked_packets == 0


### PR DESCRIPTION
## Description

Fixes banIP detection (the init script is `/etc/init.d/banip` and the package is `banip`, not `ban-ip`) across the ubus detection paths, and implements `get_banip_status` once in the backend-agnostic base client: enabled state from the init `enabled` action, plus element count and per-set / flood / invalid packet-block counters parsed from `banip report json` (direct exec, no `/bin/sh`). Removes the three duplicated, buggy per-backend overrides. Adds a "Banned IPs" element-count value and a "Blocked Packets" counter sensor (with a per-type breakdown attribute).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Tested on actual hardware (OpenWrt Version: **SNAPSHOT r35209**, banIP **1.8.10**; Device: **ArmSoM Sige5, rockchip**)

banIP is detected; element count and blocked-packet counters populate (ct-invalid / icmp-flood, and per-set inbound/outbound once counting is enabled).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes

