### PR TITLE
fix(ubus): auto-upgrade to HTTPS on redirect; aggregate multi-thread snort logs

### DIFF
--- a/custom_components/openwrt/api/ubus/client.py
+++ b/custom_components/openwrt/api/ubus/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from typing import Any
+from urllib.parse import urlsplit
 
 import aiohttp
 
@@ -68,6 +69,9 @@ class UbusClient(
         self._session_id: str = "00000000000000000000000000000000"
         self._reauth_lock = asyncio.Lock()
         self._last_connect_time: float = 0.0
+        # Set once we've checked whether the endpoint forces an http->https
+        # redirect (e.g. uhttpd `redirect_https`); see _resolve_endpoint.
+        self._endpoint_resolved: bool = False
 
         self._semaphore = asyncio.Semaphore(5)
 
@@ -295,10 +299,61 @@ class UbusClient(
                 self._last_connect_error = err
                 raise
 
+    async def _resolve_endpoint(self) -> None:
+        """Upgrade to HTTPS if the ubus endpoint redirects there.
+
+        Some hardened OpenWrt setups force HTTPS on uhttpd (``redirect_https``),
+        often on a non-standard port, so a plain-http ubus call gets a 3xx to an
+        ``https://`` URL. Following that redirect would work, but only after the
+        JSON-RPC login (password included) has already crossed the wire in
+        cleartext. Instead we probe once with a credential-free GET and, if
+        redirected to https, switch scheme/port/path before authenticating.
+
+        Runs at most once per client and is a no-op on stock http-only OpenWrt
+        (no redirect) and on explicitly SSL-configured entries.
+        """
+        if self._endpoint_resolved or self.use_ssl or self.session is None:
+            self._endpoint_resolved = True
+            return
+        try:
+            async with self.session.get(
+                self._base_url,
+                allow_redirects=False,
+                ssl=False,
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as resp:
+                location = resp.headers.get("Location", "")
+                if resp.status in (301, 302, 307, 308) and location.startswith(
+                    "https://"
+                ):
+                    parsed = urlsplit(location)
+                    new_host = parsed.hostname
+                    # urlsplit strips brackets off IPv6 literals; restore them
+                    # so _base_url rebuilds a valid "https://[addr]:port/…".
+                    if new_host and ":" in new_host:
+                        new_host = f"[{new_host}]"
+                    self.host = new_host or self.host
+                    self.port = parsed.port or 443
+                    if parsed.path:
+                        self._ubus_path = parsed.path
+                    self.use_ssl = True
+                    _LOGGER.info(
+                        "ubus endpoint redirects to HTTPS; upgraded to %s "
+                        "(certificate verification stays disabled for the "
+                        "common self-signed case unless you enable it)",
+                        self._base_url,
+                    )
+        except Exception as err:  # noqa: BLE001
+            # Non-fatal: fall back to the configured scheme and let the login
+            # attempt surface any real connection error.
+            _LOGGER.debug("ubus endpoint redirect probe failed: %s", err)
+        self._endpoint_resolved = True
+
     async def _connect(self) -> bool:
         """Authenticate with ubus."""
         if self.session is None:
             raise UbusError("Session not initialized")
+        await self._resolve_endpoint()
         session = self.session
         payload = self._build_request(
             "call",

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -718,9 +718,11 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
     async def _async_fetch_snort_data(self, data: OpenWrtData) -> None:
         """Fetch Snort IDS status and latest alert via rpcd file.exec.
 
-        Reads snort's alert_json log (/var/log/alert_json.txt) for the alert
-        count and most recent alert, plus the service running state. Note the
-        log lives on tmpfs, so the count resets on reboot (alerts since boot).
+        Reads snort's alert_json log(s) for the alert count and most recent
+        alert, plus the service running state. Multi-threaded snort writes one
+        file per packet thread (/var/log/<tid>_alert_json.txt), so the counts
+        are aggregated across all of them. Note the log lives on tmpfs, so the
+        count resets on reboot (alerts since boot).
         """
         empty: dict[str, Any] = {
             "installed": False,
@@ -745,24 +747,46 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             data.snort_status = empty
             return
 
-        # tail/wc rather than file.read: rpcd file.read truncates past ~256KB,
-        # which would blind the sensor on a large IDS log.
-        log_path = "/var/log/alert_json.txt"
+        # Snort 3 writes one alert file per packet thread when running
+        # multi-threaded (e.g. multi-queue NFQ): /var/log/<tid>_alert_json.txt.
+        # Single-thread setups write the unprefixed /var/log/alert_json.txt.
+        # Aggregate across whichever exist so the sensor works on any config.
+        # rpcd file.exec runs the binary directly (no shell), so we pass an
+        # explicit candidate list rather than a glob. tail/wc rather than
+        # file.read: rpcd file.read truncates past ~256KB, which would blind
+        # the sensor on a large IDS log.
+        log_dir = "/var/log"
+        candidates = [
+            f"{log_dir}/alert_json.txt",
+            *(f"{log_dir}/{tid}_alert_json.txt" for tid in range(16)),
+        ]
+        present: list[str] = []
         alerts: list[dict[str, Any]] = []
         count = 0
         try:
-            res = await self.client.file_exec("/usr/bin/wc", ["-l", log_path])
+            res = await self.client.file_exec("/usr/bin/wc", ["-l", *candidates])
             out = res.get("stdout", "") if isinstance(res, dict) else ""
-            m = re.search(r"\d+", out)
-            if m:
-                count = int(m.group(0))
+            # Lines look like "  <count> /var/log/<name>"; missing files only
+            # error on stderr, and the trailing "total" line (emitted only for
+            # >1 file) has no path so it fails this match and is skipped.
+            for ln in out.splitlines():
+                # Matches "<count> /path/alert_json.txt" and the per-thread
+                # "<count> /path/<tid>_alert_json.txt"; the "total" summary line
+                # has no such path and is skipped.
+                m = re.match(r"\s*(\d+)\s+(\S*alert_json\.txt)\s*$", ln)
+                if not m:
+                    continue
+                count += int(m.group(1))
+                present.append(m.group(2))
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug("snort: wc failed: %s", err)
 
-        if count:
+        if present:
             try:
+                # -q suppresses the "==> file <==" headers busybox prints for
+                # multiple files, keeping the stream pure JSONL.
                 res = await self.client.file_exec(
-                    "/usr/bin/tail", ["-n", "20", log_path]
+                    "/usr/bin/tail", ["-q", "-n", "20", *present]
                 )
                 body = res.get("stdout", "") if isinstance(res, dict) else ""
                 for ln in body.splitlines():
@@ -775,6 +799,17 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                         continue
                     if isinstance(obj, dict):
                         alerts.append(obj)
+                # Per-thread files aren't globally ordered once merged; sort by
+                # snort's epoch "seconds" field (best effort) so last_alert and
+                # recent_alerts reflect true recency, then keep the newest 20.
+                alerts.sort(
+                    key=lambda a: (
+                        a["seconds"]
+                        if isinstance(a.get("seconds"), (int, float))
+                        else 0
+                    )
+                )
+                alerts = alerts[-20:]
             except Exception as err:  # noqa: BLE001
                 _LOGGER.debug("snort: tail failed: %s", err)
 

--- a/tests/test_api_ubus.py
+++ b/tests/test_api_ubus.py
@@ -20,9 +20,10 @@ def ubus_client() -> UbusClient:
 
 
 class MockResponse:
-    def __init__(self, status, json_data):
+    def __init__(self, status, json_data, headers=None):
         self.status = status
         self._json_data = json_data
+        self.headers = headers or {}
 
     async def __aenter__(self):
         return self
@@ -40,6 +41,8 @@ class MockResponse:
 @pytest.mark.asyncio
 async def test_ubus_connect_success(ubus_client: UbusClient):
     """Test successful connection and login."""
+    # No forced-HTTPS redirect: endpoint probe sees a plain 200, stays http.
+    ubus_client.session.get = MagicMock(return_value=MockResponse(200, {}))
     mock_post = MagicMock()
     ubus_client.session.post = mock_post
     mock_post.return_value = MockResponse(
@@ -60,6 +63,7 @@ async def test_ubus_connect_success(ubus_client: UbusClient):
 @pytest.mark.asyncio
 async def test_ubus_connect_auth_error(ubus_client: UbusClient):
     """Test auth error handling."""
+    ubus_client.session.get = MagicMock(return_value=MockResponse(200, {}))
     mock_post = MagicMock()
     ubus_client.session.post = mock_post
     mock_post.return_value = MockResponse(
@@ -71,6 +75,71 @@ async def test_ubus_connect_auth_error(ubus_client: UbusClient):
 
     with pytest.raises(UbusAuthError):
         await ubus_client.connect()
+
+
+@pytest.mark.asyncio
+async def test_ubus_connect_upgrades_on_https_redirect(ubus_client: UbusClient):
+    """A forced-HTTPS redirect upgrades scheme/port before login (no cleartext)."""
+    ubus_client.session.get = MagicMock(
+        return_value=MockResponse(
+            307, {}, {"Location": "https://192.168.1.1:8443/ubus"}
+        )
+    )
+    mock_post = MagicMock(
+        return_value=MockResponse(
+            200,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": [0, {"ubus_rpc_session": "test_token"}],
+            },
+        )
+    )
+    ubus_client.session.post = mock_post
+
+    await ubus_client.connect()
+
+    assert ubus_client.use_ssl is True
+    assert ubus_client.port == 8443
+    assert ubus_client._base_url == "https://192.168.1.1:8443/ubus"
+    # login POST went to the upgraded https URL, not the original http one
+    assert mock_post.call_args.args[0] == "https://192.168.1.1:8443/ubus"
+
+
+@pytest.mark.asyncio
+async def test_ubus_upgrade_preserves_ipv6_brackets(ubus_client: UbusClient):
+    """An IPv6 redirect target keeps its brackets so _base_url stays valid."""
+    ubus_client.session.get = MagicMock(
+        return_value=MockResponse(307, {}, {"Location": "https://[fd00::1]:8443/ubus"})
+    )
+    ubus_client.session.post = MagicMock(
+        return_value=MockResponse(
+            200,
+            {"jsonrpc": "2.0", "id": 1, "result": [0, {"ubus_rpc_session": "t"}]},
+        )
+    )
+
+    await ubus_client.connect()
+
+    assert ubus_client.host == "[fd00::1]"
+    assert ubus_client._base_url == "https://[fd00::1]:8443/ubus"
+
+
+@pytest.mark.asyncio
+async def test_ubus_probe_skipped_when_ssl_configured(ubus_client: UbusClient):
+    """When the entry is already SSL, no redirect probe GET is issued."""
+    ubus_client.use_ssl = True
+    ubus_client.session.get = MagicMock()
+    ubus_client.session.post = MagicMock(
+        return_value=MockResponse(
+            200,
+            {"jsonrpc": "2.0", "id": 1, "result": [0, {"ubus_rpc_session": "t"}]},
+        )
+    )
+
+    await ubus_client.connect()
+
+    ubus_client.session.get.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_snort.py
+++ b/tests/test_snort.py
@@ -59,6 +59,37 @@ async def test_snort_parses_alerts():
 
 
 @pytest.mark.asyncio
+async def test_snort_aggregates_thread_files():
+    """Multi-threaded snort writes one file per packet thread; counts sum."""
+    # busybox `wc -l` over the candidate list: two present files + total line
+    # (missing candidates only error on stderr, which file_exec drops).
+    wc = (
+        "       1 /var/log/0_alert_json.txt\n"
+        "       1 /var/log/2_alert_json.txt\n"
+        "       2 total\n"
+    )
+    # `tail -q` streams the merged JSONL from both threads, out of order;
+    # coordinator sorts by the epoch "seconds" field.
+    a_old = _A1.replace("}", ',"seconds":1000}')
+    a_new = _A2.replace("}", ',"seconds":2000}')
+    coord = SimpleNamespace(
+        client=SimpleNamespace(
+            file_exec=AsyncMock(
+                side_effect=_make_exec(wc=wc, tail=a_new + "\n" + a_old + "\n")
+            )
+        )
+    )
+    data = OpenWrtData()
+    await OpenWrtDataCoordinator._async_fetch_snort_data(coord, data)
+    s = data.snort_status
+    assert s["alert_count"] == 2  # summed across threads, "total" line ignored
+    assert len(s["recent_alerts"]) == 2
+    # sorted by seconds despite reversed input; newest first for display
+    assert s["last_alert"]["message"] == "SECOND | ALERT"
+    assert s["recent_alerts"][0]["message"] == "SECOND | ALERT"
+
+
+@pytest.mark.asyncio
 async def test_snort_not_installed():
     coord = SimpleNamespace(
         client=SimpleNamespace(


### PR DESCRIPTION
## Summary

Two robustness fixes for hardened / non-default OpenWrt setups. Both are no-ops on stock configurations.

### 1. ubus client: auto-upgrade to HTTPS on redirect
When uhttpd is configured to force HTTPS (`redirect_https`), a plain-http ubus call is redirected (3xx) to an `https://` URL, often on a non-standard port. aiohttp would follow that redirect, but only *after* the JSON-RPC login — password included — has already crossed the wire in cleartext.

`_resolve_endpoint()` now probes once with a credential-free `GET` (`allow_redirects=False`). If it sees a redirect to `https://`, it switches scheme/port/path *before* authenticating, so credentials only ever travel over HTTPS. It is a no-op on http-only OpenWrt and on entries already configured for SSL, and the result is cached so it runs at most once per client.

### 2. snort sensor: aggregate multi-thread alert logs
Snort 3 running multi-threaded (e.g. multi-queue NFQ) writes one alert file per packet thread — `/var/log/<tid>_alert_json.txt` — instead of a single `/var/log/alert_json.txt`. The sensor now sums counts and merges recent alerts across whichever files exist (an explicit candidate list, since rpcd `file.exec` has no shell for glob expansion), and sorts the merged alerts by snort's epoch `seconds` field. Single-thread setups that use the unprefixed file continue to work unchanged.

## Tests
Added coverage for the HTTPS-upgrade probe (redirect triggers upgrade; probe is skipped when SSL is already configured) and for multi-thread snort aggregation (summed counts, `total` line ignored, recency sort). The existing suite continues to pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically upgrades connections to HTTPS when the router redirects requests.
  * Supports Snort 3 alert monitoring across multiple packet-processing threads.
  * Displays the most recent Snort alerts in accurate chronological order.

* **Bug Fixes**
  * Prevents unnecessary endpoint probing when secure connections are already configured.

* **Tests**
  * Added coverage for HTTPS redirects, secure connection handling, and multi-threaded Snort alert aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->