### PR TITLE
fix(ubus): support GL.iNet LuCI proxy

### DIFF
--- a/custom_components/openwrt/api/ubus/client.py
+++ b/custom_components/openwrt/api/ubus/client.py
@@ -267,12 +267,29 @@ class UbusClient(
             _LOGGER.debug("Failed to list ubus objects: %s", err)
             return []
 
-        result = data.get("result")
-        if not result or not isinstance(result, list):
+        result = self._unwrap_list_result(data.get("result"))
+        if not result:
             return []
 
-        # On success, result is a list with one dict: [{"object1": {...}, "object2": {...}}]
-        return list(result[0].keys())
+        objects = list(result)
+        if objects != ["*"]:
+            return objects
+
+        core_objects = ("system", "network.interface", "uci", "file", "session")
+        return [
+            object_name
+            for object_name in core_objects
+            if await self._get_object_methods(object_name)
+        ]
+
+    @staticmethod
+    def _unwrap_list_result(result: Any) -> dict[str, Any]:
+        """Return an object map from standard and proxy ubus list responses."""
+        if isinstance(result, list):
+            if result and isinstance(result[0], dict):
+                return result[0]
+            return {}
+        return result if isinstance(result, dict) else {}
 
     async def _get_object_methods(self, object_name: str) -> dict[str, Any]:
         """Get methods for a specific ubus object."""
@@ -294,9 +311,8 @@ class UbusClient(
             ) as response:
                 response.raise_for_status()
                 data = await response.json()
-                result = data.get("result")
-                if result and isinstance(result, list) and len(result) > 0:
-                    return result[0].get(object_name, {})
+                result = self._unwrap_list_result(data.get("result"))
+                return result.get(object_name, {})
         except Exception:
             pass
         return {}

--- a/custom_components/openwrt/api/ubus/network.py
+++ b/custom_components/openwrt/api/ubus/network.py
@@ -40,12 +40,15 @@ class UbusNetworkMixin:
         """Get wireless interface information."""
         interfaces: list[WirelessInterface] = []
         iface_names: set[str] = set()
+        radio_names: set[str] = set()
+        skip_iwinfo_info = self._ubus_path.rstrip("/") == "/cgi-bin/luci/admin/ubus"
 
         # 1. Primary source: network.wireless status
         if self.packages.wireless is not False:
             try:
                 wireless_data = await self._call("network.wireless", "status")
                 if wireless_data and isinstance(wireless_data, dict):
+                    radio_names.update(wireless_data)
                     for radio_name, radio_data in wireless_data.items():
                         if not isinstance(radio_data, dict):
                             continue
@@ -160,7 +163,7 @@ class UbusNetworkMixin:
                 candidates = iw_devs["devices"]
 
             for name in candidates:
-                if name in iface_names:
+                if skip_iwinfo_info or name in iface_names or name in radio_names:
                     continue
 
                 # Check if any existing interface from UCI matches this physical device
@@ -199,6 +202,8 @@ class UbusNetworkMixin:
 
         # 3. Populate metrics for all discovered interfaces in parallel
         async def _fetch_metrics(wifi: WirelessInterface) -> None:
+            if skip_iwinfo_info:
+                return
             try:
                 iwinfo = await self._call("iwinfo", "info", {"device": wifi.name})
                 if iwinfo:

--- a/custom_components/openwrt/api/ubus/network.py
+++ b/custom_components/openwrt/api/ubus/network.py
@@ -202,10 +202,10 @@ class UbusNetworkMixin:
 
         # 3. Populate metrics for all discovered interfaces in parallel
         async def _fetch_metrics(wifi: WirelessInterface) -> None:
-            if skip_iwinfo_info:
-                return
             try:
-                iwinfo = await self._call("iwinfo", "info", {"device": wifi.name})
+                iwinfo = {}
+                if not skip_iwinfo_info:
+                    iwinfo = await self._call("iwinfo", "info", {"device": wifi.name})
                 if iwinfo:
                     if not wifi.ssid:
                         wifi.ssid = iwinfo.get("ssid", "")

--- a/tests/test_api_ubus.py
+++ b/tests/test_api_ubus.py
@@ -143,6 +143,52 @@ async def test_ubus_probe_skipped_when_ssl_configured(ubus_client: UbusClient):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        ([{"system": {}, "uci": {}}], ["system", "uci"]),
+        ({"system": {}, "uci": {}}, ["system", "uci"]),
+    ],
+)
+async def test_ubus_list_objects_response_formats(
+    ubus_client: UbusClient, result, expected
+):
+    """Test standard and direct object-map list responses."""
+    ubus_client._connected = True
+    ubus_client.session.post = MagicMock(
+        return_value=MockResponse(200, {"result": result})
+    )
+
+    assert await ubus_client._list_objects() == expected
+
+
+@pytest.mark.asyncio
+async def test_ubus_list_objects_literal_wildcard(ubus_client: UbusClient):
+    """Test probing core objects when a proxy treats the wildcard literally."""
+    ubus_client._connected = True
+    ubus_client.session.post = MagicMock(
+        return_value=MockResponse(200, {"result": {"*": {}}})
+    )
+    ubus_client._get_object_methods = AsyncMock(
+        side_effect=lambda name: {"methods": {}} if name in {"system", "uci"} else {}
+    )
+
+    assert await ubus_client._list_objects() == ["system", "uci"]
+
+
+@pytest.mark.asyncio
+async def test_ubus_get_object_methods_direct_response(ubus_client: UbusClient):
+    """Test method discovery through a direct object-map response."""
+    ubus_client.session.post = MagicMock(
+        return_value=MockResponse(
+            200, {"result": {"uci": {"get": {"config": "String"}}}}
+        )
+    )
+
+    assert await ubus_client._get_object_methods("uci") == {"get": {"config": "String"}}
+
+
+@pytest.mark.asyncio
 async def test_ubus_get_device_info(ubus_client: UbusClient):
     """Test fetching device info."""
     ubus_client._session_id = "test_token"
@@ -459,6 +505,80 @@ async def test_ubus_get_wireless_interfaces_matching(ubus_client: UbusClient):
         assert wifi5g.ifname == "wlan1"
         assert wifi5g.band == "5 GHz"
         assert wifi5g.channel == 36
+
+
+@pytest.mark.asyncio
+async def test_ubus_wireless_skips_radio_info(ubus_client: UbusClient):
+    """Test that physical radio names are not queried as iwinfo interfaces."""
+    ubus_client.packages.wireless = True
+
+    with patch.object(ubus_client, "_call", new_callable=AsyncMock) as mock_call:
+
+        def call_side_effect(object_name, method, params=None, *args, **kwargs):
+            if object_name == "network.wireless" and method == "status":
+                return {
+                    "radio0": {
+                        "config": {"band": "2g"},
+                        "interfaces": [
+                            {
+                                "section": "default_radio0",
+                                "ifname": "wlan0",
+                                "config": {"ssid": "Test"},
+                            }
+                        ],
+                    }
+                }
+            if object_name == "iwinfo" and method == "devices":
+                return ["radio0"]
+            if object_name == "iwinfo" and method == "info":
+                assert params == {"device": "wlan0"}
+                return {"channel": 1}
+            return {}
+
+        mock_call.side_effect = call_side_effect
+
+        interfaces = await ubus_client.get_wireless_interfaces()
+
+    assert len(interfaces) == 1
+    assert interfaces[0].channel == 1
+
+
+@pytest.mark.asyncio
+async def test_ubus_wireless_skips_info_for_luci_admin_proxy(
+    ubus_client: UbusClient,
+):
+    """Test avoiding iwinfo info calls that hang GL.iNet's LuCI proxy."""
+    ubus_client.packages.wireless = True
+    ubus_client._ubus_path = "/cgi-bin/luci/admin/ubus"
+
+    with patch.object(ubus_client, "_call", new_callable=AsyncMock) as mock_call:
+
+        def call_side_effect(object_name, method, *args, **kwargs):
+            if object_name == "network.wireless" and method == "status":
+                return {
+                    "wifi0": {
+                        "config": {"band": "2g", "hwmode": "11beg"},
+                        "interfaces": [
+                            {
+                                "section": "iot2g",
+                                "ifname": "wlan06",
+                                "config": {"ssid": "Test"},
+                            }
+                        ],
+                    }
+                }
+            if object_name == "iwinfo" and method == "devices":
+                return ["wifi0", "wlan06"]
+            if object_name == "iwinfo" and method == "info":
+                pytest.fail("iwinfo info must not be called through this proxy")
+            return {}
+
+        mock_call.side_effect = call_side_effect
+
+        interfaces = await ubus_client.get_wireless_interfaces()
+
+    assert len(interfaces) == 1
+    assert interfaces[0].name == "wlan06"
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_ubus.py
+++ b/tests/test_api_ubus.py
@@ -571,6 +571,8 @@ async def test_ubus_wireless_skips_info_for_luci_admin_proxy(
                 return ["wifi0", "wlan06"]
             if object_name == "iwinfo" and method == "info":
                 pytest.fail("iwinfo info must not be called through this proxy")
+            if object_name == "iwinfo" and method == "assoclist":
+                return {"results": [{"mac": "00:11:22:33:44:55"}]}
             return {}
 
         mock_call.side_effect = call_side_effect
@@ -579,6 +581,7 @@ async def test_ubus_wireless_skips_info_for_luci_admin_proxy(
 
     assert len(interfaces) == 1
     assert interfaces[0].name == "wlan06"
+    assert interfaces[0].clients_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- accept standard list-wrapped and direct object-map ubus `list` responses
- probe core objects when a LuCI proxy treats `*` as a literal object name
- exclude physical radio names from `iwinfo.info` interface probes
- skip `iwinfo.info` details on the GL.iNet LuCI admin proxy while retaining `assoclist` and `hostapd.get_clients` presence data
- add regression tests for each response and wireless scan case

## Motivation

On a GL.iNet BE9300, the LuCI ubus proxy returns a direct object map instead of the standard list wrapper. Its `iwinfo.devices` response also includes physical radio names. Calls to `iwinfo.info` for the active Wi-Fi interfaces hang and eventually make `rpcd` exit with code 139. After that, Home Assistant receives misleading authentication and ACL failures.

`iwinfo.assoclist` and `hostapd.get_clients` remain stable, so the proxy-specific guard preserves device presence while avoiding the crashing optional metrics calls. Standard `/ubus` users retain the existing metrics behavior.

## Validation

- `pytest -q tests/test_api_ubus.py`: 26 passed
- full suite: 258 passed, one unrelated existing GPS test failure (`test_async_update_gps_location` receives a mocked datetime)
- Ruff checks and formatting pass for all changed files
- live GL-BE9300 poll completed in 13.6 seconds; `rpcd` remained running and the affected tracker changed to `home`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with standard and proxied router responses when discovering available services.
  * Fixed wildcard service listings so only supported, callable services are reported.
  * Improved wireless discovery by avoiding duplicate physical radios.
  * Added support for LuCI-based router endpoints that do not provide wireless metrics through the usual interface.
  * Wireless interface detection is now more accurate across supported OpenWrt configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->