### PR TITLE
fix(sensor): enable client RX/TX rate sensors by default (#62)

### DIFF
--- a/custom_components/openwrt/__init__.py
+++ b/custom_components/openwrt/__init__.py
@@ -150,6 +150,23 @@ def _async_migrate_entity_units(hass: HomeAssistant, entry: ConfigEntry) -> None
                 )
 
 
+def _async_enable_device_rate_sensors(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Enable RX/TX rate sensors created as integration-disabled by older versions."""
+    ent_reg = er.async_get(hass)
+    entries = er.async_entries_for_config_entry(ent_reg, entry.entry_id)
+
+    for ent in entries:
+        if ent.domain != "sensor":
+            continue
+        if ent.disabled_by is None:
+            continue
+        if getattr(ent.disabled_by, "value", ent.disabled_by) != "integration":
+            continue
+        uid = ent.unique_id or ""
+        if uid.endswith("_device_rx_rate") or uid.endswith("_device_tx_rate"):
+            ent_reg.async_update_entity(ent.entity_id, disabled_by=None)
+
+
 async def _async_cleanup_disabled_features(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> None:
@@ -294,6 +311,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         # Clear any stale unit_of_measurement overrides from previous versions
         _async_migrate_entity_units(hass, entry)
+        _async_enable_device_rate_sensors(hass, entry)
 
         # Clean up any entities or devices from disabled features
         await _async_cleanup_disabled_features(hass, entry)

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -1921,6 +1921,7 @@ def _create_device_sensors(
             "Signal Strength",
             "device_signal",
             "dBm",
+            False,
             lambda d, m=mac: next(
                 (x.signal for x in d.connected_devices if x.mac and x.mac.lower() == m),
                 None,
@@ -1935,6 +1936,7 @@ def _create_device_sensors(
             "RX Rate",
             "device_rx_rate",
             "Mbps",
+            True,
             lambda d, m=mac: next(
                 (
                     round(x.rx_rate / 1000, 1)
@@ -1953,6 +1955,7 @@ def _create_device_sensors(
             "TX Rate",
             "device_tx_rate",
             "Mbps",
+            True,
             lambda d, m=mac: next(
                 (
                     round(x.tx_rate / 1000, 1)
@@ -1971,6 +1974,7 @@ def _create_device_sensors(
             "Noise Level",
             "device_noise",
             "dBm",
+            False,
             lambda d, m=mac: next(
                 (x.noise for x in d.connected_devices if x.mac and x.mac.lower() == m),
                 None,
@@ -1994,13 +1998,13 @@ def _create_device_sensors(
                 native_unit_of_measurement=unit,
                 state_class=SensorStateClass.MEASUREMENT if unit else None,
                 entity_category=EntityCategory.DIAGNOSTIC,
-                entity_registry_enabled_default=False,
+                entity_registry_enabled_default=enabled_default,
             ),
             v_fn,
             a_fn,
             dev_name,
         )
-        for key, name, tkey, unit, v_fn, a_fn in descriptions
+        for key, name, tkey, unit, enabled_default, v_fn, a_fn in descriptions
     ]
 
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -82,6 +82,44 @@ async def test_migration_v1_to_v2_exceptions(hass: HomeAssistant):
         mock_client.disconnect.assert_called_once()
 
 
+def test_enable_existing_device_rate_sensors(hass: HomeAssistant) -> None:
+    """Test that existing integration-disabled rate entities are enabled on setup."""
+    from custom_components.openwrt import _async_enable_device_rate_sensors
+
+    def make_entity(entity_id: str, unique_id: str) -> MagicMock:
+        ent = MagicMock()
+        ent.domain = "sensor"
+        ent.entity_id = entity_id
+        ent.unique_id = unique_id
+        ent.disabled_by = "integration"
+        return ent
+
+    ent_rx = make_entity("sensor.device_rx_rate", "entry_device_rx_rate")
+    ent_tx = make_entity("sensor.device_tx_rate", "entry_device_tx_rate")
+    ent_signal = make_entity("sensor.device_signal", "entry_device_signal")
+
+    ent_reg = MagicMock()
+    entry = MagicMock()
+    entry.entry_id = "entry"
+
+    with (
+        patch("custom_components.openwrt.er.async_get", return_value=ent_reg),
+        patch(
+            "custom_components.openwrt.er.async_entries_for_config_entry",
+            return_value=[ent_rx, ent_tx, ent_signal],
+        ),
+    ):
+        _async_enable_device_rate_sensors(hass, entry)
+
+    assert ent_reg.async_update_entity.call_count == 2
+    ent_reg.async_update_entity.assert_any_call(
+        ent_rx.entity_id, disabled_by=None
+    )
+    ent_reg.async_update_entity.assert_any_call(
+        ent_tx.entity_id, disabled_by=None
+    )
+
+
 @pytest.mark.asyncio
 async def test_coordinator_unique_id_migration_and_aliasing(hass) -> None:
     """Test that unique_id is migrated from IP/legacy MAC and aliased in identifiers."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -136,6 +136,24 @@ def test_device_sensor_case_insensitivity() -> None:
             assert sensor.native_value == -95
 
 
+def test_device_rate_sensors_enabled_by_default() -> None:
+    """Test that client RX/TX rate sensors are enabled for new installations."""
+    from custom_components.openwrt.api.base import ConnectedDevice
+    from custom_components.openwrt.sensor import _create_device_sensors
+
+    device = ConnectedDevice(mac="aa:bb:cc:dd:ee:ff", is_wireless=True)
+    entry = MagicMock()
+    entry.entry_id = "test"
+
+    sensors = _create_device_sensors(MagicMock(), entry, device)
+    by_key = {s.entity_description.key: s for s in sensors}
+
+    assert by_key["device_rx_rate"]._attr_entity_registry_enabled_default is True
+    assert by_key["device_tx_rate"]._attr_entity_registry_enabled_default is True
+    assert by_key["device_signal"]._attr_entity_registry_enabled_default is False
+    assert by_key["device_noise"]._attr_entity_registry_enabled_default is False
+
+
 def test_assoc_rate_robustness() -> None:
     """Test that _get_assoc_rate successfully parses multiple nested formats from iwinfo and hostapd."""
     from custom_components.openwrt.api.base import OpenWrtClient


### PR DESCRIPTION
## Summary

The client RX/TX rate data is already parsed correctly in current main (verified against the reporter's Home Assistant: `sensor.sheng_tai_pen_rx_rate` reports `6.0 Mbps` and `sensor.sheng_tai_pen_tx_rate` reports `13.0 Mbps`). The remaining user-visible problem is that these entities are created as `integration`-disabled and existing registry entries stay disabled after upgrades.

## Changes

- Enable new device RX/TX rate sensors by default.
- Keep Signal Strength and Noise Level diagnostic entities disabled as before.
- On config entry setup, enable existing rate entities that are still disabled only by the integration, without overriding a user's manual disable.
- Add unit tests for the new default and the registry migration.

## Verification

- `py_compile` passed for modified files.
- Full pytest could not be run locally because this workspace lacks the Home Assistant test dependencies.
