### PR TITLE
fix(config_flow): make tracked-device selection usable in the options flow

### DIFF
--- a/custom_components/openwrt/config_flow.py
+++ b/custom_components/openwrt/config_flow.py
@@ -2362,7 +2362,9 @@ class OpenWrtOptionsFlow(OptionsFlow):
             for device in coordinator.data.all_connected_devices:
                 if not device.mac:
                     continue
-                name = device.hostname or device.mac
+                # "*" is dnsmasq's placeholder for a client that sent no hostname
+                hostname = "" if device.hostname == "*" else device.hostname
+                name = hostname or device.mac
                 device_options[device.mac.lower()] = f"{name} ({device.mac})"
 
         # History keeps devices that were seen before but are offline right now

--- a/custom_components/openwrt/config_flow.py
+++ b/custom_components/openwrt/config_flow.py
@@ -2346,17 +2346,37 @@ class OpenWrtOptionsFlow(OptionsFlow):
         coordinator = self.hass.data[DOMAIN][self._config_entry.entry_id][
             DATA_COORDINATOR
         ]
-        devices = coordinator._device_history
 
-        device_options = {}
-        for mac, info in devices.items():
-            if not isinstance(info, dict):
+        current = self._config_entry.options.get(CONF_TRACKED_DEVICES, [])
+        current_manual = self._config_entry.options.get(CONF_MANUAL_TRACKED_DEVICES, "")
+
+        # Candidates must come from the *unfiltered* device list. Only whitelisted
+        # devices are ever written to _device_history, so sourcing candidates from
+        # history alone makes them equal to the current selection — and a
+        # multi-select only offers unselected options, so the dropdown renders
+        # empty and the tracked set can never grow. all_connected_devices ignores
+        # the whitelist (see the all_devices/filtered_devices split in the
+        # coordinator) and carries real hostnames for readable labels.
+        device_options: dict[str, str] = {}
+        if coordinator.data:
+            for device in coordinator.data.all_connected_devices:
+                if not device.mac:
+                    continue
+                name = device.hostname or device.mac
+                device_options[device.mac.lower()] = f"{name} ({device.mac})"
+
+        # History keeps devices that were seen before but are offline right now
+        # selectable.
+        for mac, info in coordinator._device_history.items():
+            if not isinstance(info, dict) or mac in device_options:
                 continue
             name = info.get("hostname") or info.get("name") or mac
             device_options[mac] = f"{name} ({mac})"
 
-        current = self._config_entry.options.get(CONF_TRACKED_DEVICES, [])
-        current_manual = self._config_entry.options.get(CONF_MANUAL_TRACKED_DEVICES, "")
+        # An already tracked device that the coordinator has not seen yet must
+        # stay in the list, otherwise the stored selection is not a valid option.
+        for mac in current:
+            device_options.setdefault(mac, mac)
 
         # Prepare device options for selector
         options: list[selector.SelectOptionDict] = [

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -1267,12 +1267,16 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             if mac in forced_wireless:
                 device.is_wireless = True
 
+            # dnsmasq reports "*" for clients that sent no hostname; treat it as
+            # absent so it never ends up as a device label.
+            hostname = "" if device.hostname == "*" else device.hostname
+
             if mac not in self._device_history:
                 self._device_history[mac] = {
                     "initially_seen": current_time,
                     "last_seen": current_time,
                     "is_wireless": device.is_wireless,
-                    "hostname": device.hostname,
+                    "hostname": hostname,
                 }
                 history_updated = True
                 _LOGGER.debug("New device added to history: %s", mac)
@@ -1284,9 +1288,10 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 if device.is_wireless and not hist.get("is_wireless"):
                     hist["is_wireless"] = True
                 # Keep the last known hostname so offline devices stay readable
-                # in the options flow and MQTT discovery.
-                if device.hostname:
-                    hist["hostname"] = device.hostname
+                # in the options flow and MQTT discovery. Never overwrite a good
+                # hostname with a missing one.
+                if hostname:
+                    hist["hostname"] = hostname
                 history_updated = True
 
             # Sync with shared wireless history for multi-AP coordination
@@ -1332,6 +1337,9 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 lease.ip,
             )
 
+            # "*" means the client sent no hostname — see the connected device loop
+            lease_hostname = "" if lease.hostname == "*" else lease.hostname
+
             # Ensure lease devices are also in history so they are discovered as trackers
             if mac not in self._device_history:
                 is_wireless = is_random_mac(mac)
@@ -1339,7 +1347,7 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                     "initially_seen": current_time,
                     "last_seen": current_time,
                     "is_wireless": is_wireless,
-                    "hostname": lease.hostname,
+                    "hostname": lease_hostname,
                 }
                 history_updated = True
                 _LOGGER.debug(
@@ -1349,8 +1357,8 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 )
             else:
                 self._device_history[mac]["last_seen"] = current_time
-                if lease.hostname:
-                    self._device_history[mac]["hostname"] = lease.hostname
+                if lease_hostname:
+                    self._device_history[mac]["hostname"] = lease_hostname
                 history_updated = True
 
             filtered_leases.append(lease)

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -1272,6 +1272,7 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                     "initially_seen": current_time,
                     "last_seen": current_time,
                     "is_wireless": device.is_wireless,
+                    "hostname": device.hostname,
                 }
                 history_updated = True
                 _LOGGER.debug("New device added to history: %s", mac)
@@ -1282,6 +1283,10 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 # to avoid fake-wired entries from DHCP leases when offline.
                 if device.is_wireless and not hist.get("is_wireless"):
                     hist["is_wireless"] = True
+                # Keep the last known hostname so offline devices stay readable
+                # in the options flow and MQTT discovery.
+                if device.hostname:
+                    hist["hostname"] = device.hostname
                 history_updated = True
 
             # Sync with shared wireless history for multi-AP coordination
@@ -1334,6 +1339,7 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                     "initially_seen": current_time,
                     "last_seen": current_time,
                     "is_wireless": is_wireless,
+                    "hostname": lease.hostname,
                 }
                 history_updated = True
                 _LOGGER.debug(
@@ -1343,6 +1349,8 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 )
             else:
                 self._device_history[mac]["last_seen"] = current_time
+                if lease.hostname:
+                    self._device_history[mac]["hostname"] = lease.hostname
                 history_updated = True
 
             filtered_leases.append(lease)

--- a/tests/test_selective_tracking.py
+++ b/tests/test_selective_tracking.py
@@ -12,8 +12,18 @@ from custom_components.openwrt.api.base import (
     OpenWrtData,
     SystemResources,
 )
-from custom_components.openwrt.const import CONF_TRACKED_DEVICES
+from custom_components.openwrt.const import (
+    CONF_TRACKED_DEVICES,
+    DATA_COORDINATOR,
+    DOMAIN,
+)
 from custom_components.openwrt.coordinator import OpenWrtDataCoordinator
+
+
+def _tracked_device_options(flow_result_selector) -> dict[str, str]:
+    """Return the {value: label} mapping offered by the tracked devices selector."""
+    options = flow_result_selector.call_args.kwargs["options"]
+    return {opt["value"]: opt["label"] for opt in options}
 
 
 @pytest.mark.asyncio
@@ -207,3 +217,153 @@ async def test_coordinator_client_counts_ignore_whitelist() -> None:
     assert connected_count == 3
     assert wireless_count == 2
     assert wired_count == 1
+
+
+def _make_options_flow(all_connected_devices, device_history, tracked):
+    """Build an options flow wired to a coordinator with the given state."""
+    from custom_components.openwrt.config_flow import OpenWrtOptionsFlow
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.options = {CONF_TRACKED_DEVICES: tracked}
+
+    coordinator = MagicMock()
+    coordinator.data = OpenWrtData(all_connected_devices=all_connected_devices)
+    coordinator._device_history = device_history
+
+    hass = MagicMock()
+    hass.data = {DOMAIN: {config_entry.entry_id: {DATA_COORDINATOR: coordinator}}}
+
+    flow = OpenWrtOptionsFlow(config_entry)
+    flow.hass = hass
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_options_flow_offers_untracked_devices() -> None:
+    """Untracked devices must be selectable in the options flow.
+
+    Regression test: candidates used to come from _device_history alone, which
+    only ever receives whitelisted devices. The candidate list then equalled the
+    current selection, so the multi-select rendered with nothing to pick and the
+    tracked set could never grow.
+    """
+    flow = _make_options_flow(
+        all_connected_devices=[
+            ConnectedDevice(mac="00:BB:CC:DD:EE:01", hostname="device1"),
+            ConnectedDevice(mac="00:BB:CC:DD:EE:02", hostname="device2"),
+            ConnectedDevice(mac="00:BB:CC:DD:EE:03", hostname="device3"),
+        ],
+        # Only the whitelisted device ever made it into history.
+        device_history={
+            "00:bb:cc:dd:ee:01": {"initially_seen": 1.0, "last_seen": 2.0},
+        },
+        tracked=["00:bb:cc:dd:ee:01"],
+    )
+
+    with patch("custom_components.openwrt.config_flow.selector") as mock_selector:
+        result = await flow.async_step_options_select_devices()
+
+    assert result["step_id"] == "options_select_devices"
+
+    options = _tracked_device_options(mock_selector.SelectSelectorConfig)
+    assert set(options) == {
+        "00:bb:cc:dd:ee:01",
+        "00:bb:cc:dd:ee:02",
+        "00:bb:cc:dd:ee:03",
+    }
+    # The two untracked devices are what makes the dropdown usable at all.
+    assert set(options) - {"00:bb:cc:dd:ee:01"}
+
+    # Hostnames come from the live device list, not the MAC-only history.
+    assert options["00:bb:cc:dd:ee:02"] == "device2 (00:BB:CC:DD:EE:02)"
+
+
+@pytest.mark.asyncio
+async def test_options_flow_keeps_offline_and_selected_devices() -> None:
+    """Offline history devices and stored selections stay selectable."""
+    flow = _make_options_flow(
+        all_connected_devices=[
+            ConnectedDevice(mac="00:bb:cc:dd:ee:01", hostname="device1"),
+        ],
+        device_history={
+            "00:bb:cc:dd:ee:01": {"hostname": "device1"},
+            # Seen before, currently offline.
+            "00:bb:cc:dd:ee:09": {"hostname": "laptop"},
+            # Defensive: stored history is not guaranteed to hold dicts.
+            "00:bb:cc:dd:ee:99": "corrupt",
+        },
+        # Tracked but never seen by this coordinator yet.
+        tracked=["00:bb:cc:dd:ee:01", "00:bb:cc:dd:ee:aa"],
+    )
+
+    with patch("custom_components.openwrt.config_flow.selector") as mock_selector:
+        await flow.async_step_options_select_devices()
+
+    options = _tracked_device_options(mock_selector.SelectSelectorConfig)
+
+    # Offline device keeps its stored hostname.
+    assert options["00:bb:cc:dd:ee:09"] == "laptop (00:bb:cc:dd:ee:09)"
+    # Every stored selection remains a valid option.
+    assert "00:bb:cc:dd:ee:aa" in options
+    assert "00:bb:cc:dd:ee:99" not in options
+
+
+@pytest.mark.asyncio
+async def test_options_flow_without_coordinator_data() -> None:
+    """A coordinator that has not completed a refresh must not break the form."""
+    flow = _make_options_flow(
+        all_connected_devices=[],
+        device_history={"00:bb:cc:dd:ee:01": {"hostname": "device1"}},
+        tracked=["00:bb:cc:dd:ee:01"],
+    )
+    flow.hass.data[DOMAIN]["test_entry"][DATA_COORDINATOR].data = None
+
+    with patch("custom_components.openwrt.config_flow.selector") as mock_selector:
+        result = await flow.async_step_options_select_devices()
+
+    assert result["step_id"] == "options_select_devices"
+    options = _tracked_device_options(mock_selector.SelectSelectorConfig)
+    assert options == {"00:bb:cc:dd:ee:01": "device1 (00:bb:cc:dd:ee:01)"}
+
+
+@pytest.mark.asyncio
+async def test_device_history_records_hostname() -> None:
+    """History must persist hostnames so offline devices stay readable."""
+    hass = MagicMock()
+    hass.loop = MagicMock()
+    hass.loop.time = MagicMock(return_value=123456789.0)
+
+    config_entry = MagicMock()
+    config_entry.options = {}
+    config_entry.data = {"host": "192.168.1.1"}
+    config_entry.entry_id = "test_entry"
+
+    mock_client = AsyncMock()
+    mock_client.connected = True
+    mock_client.get_all_data.return_value = OpenWrtData(
+        system_resources=SystemResources(uptime=100),
+        connected_devices=[
+            ConnectedDevice(
+                mac="00:bb:cc:dd:ee:01",
+                hostname="device1",
+                interface="br-lan",
+                is_wireless=True,
+            ),
+        ],
+        dhcp_leases=[
+            DhcpLease(mac="00:bb:cc:dd:ee:02", hostname="printer", ip="192.168.1.11"),
+        ],
+        network_interfaces=[],
+        wireless_interfaces=[],
+    )
+
+    with patch("custom_components.openwrt.coordinator.storage.Store") as mock_store:
+        mock_store.return_value.async_load = AsyncMock(return_value={})
+        mock_store.return_value.async_save = AsyncMock()
+        coordinator = OpenWrtDataCoordinator(hass, config_entry, mock_client)
+
+    await coordinator._async_update_data()
+
+    assert coordinator._device_history["00:bb:cc:dd:ee:01"]["hostname"] == "device1"
+    assert coordinator._device_history["00:bb:cc:dd:ee:02"]["hostname"] == "printer"

--- a/tests/test_selective_tracking.py
+++ b/tests/test_selective_tracking.py
@@ -367,3 +367,123 @@ async def test_device_history_records_hostname() -> None:
 
     assert coordinator._device_history["00:bb:cc:dd:ee:01"]["hostname"] == "device1"
     assert coordinator._device_history["00:bb:cc:dd:ee:02"]["hostname"] == "printer"
+
+
+@pytest.mark.asyncio
+async def test_device_history_ignores_placeholder_hostname() -> None:
+    """dnsmasq's "*" placeholder must never be stored or shown as a hostname."""
+    hass = MagicMock()
+    hass.loop = MagicMock()
+    hass.loop.time = MagicMock(return_value=123456789.0)
+
+    config_entry = MagicMock()
+    config_entry.options = {}
+    config_entry.data = {"host": "192.168.1.1"}
+    config_entry.entry_id = "test_entry"
+
+    mock_client = AsyncMock()
+    mock_client.connected = True
+
+    def _data(device_hostname: str, lease_hostname: str) -> OpenWrtData:
+        return OpenWrtData(
+            system_resources=SystemResources(uptime=100),
+            connected_devices=[
+                ConnectedDevice(
+                    mac="00:bb:cc:dd:ee:01",
+                    hostname=device_hostname,
+                    interface="br-lan",
+                    is_wireless=True,
+                ),
+            ],
+            dhcp_leases=[
+                DhcpLease(
+                    mac="00:bb:cc:dd:ee:02",
+                    hostname=lease_hostname,
+                    ip="192.168.1.11",
+                ),
+            ],
+            network_interfaces=[],
+            wireless_interfaces=[],
+        )
+
+    with patch("custom_components.openwrt.coordinator.storage.Store") as mock_store:
+        mock_store.return_value.async_load = AsyncMock(return_value={})
+        mock_store.return_value.async_save = AsyncMock()
+        coordinator = OpenWrtDataCoordinator(hass, config_entry, mock_client)
+
+    # First refresh: both report a real hostname.
+    mock_client.get_all_data.return_value = _data("device1", "printer")
+    await coordinator._async_update_data()
+
+    assert coordinator._device_history["00:bb:cc:dd:ee:01"]["hostname"] == "device1"
+    assert coordinator._device_history["00:bb:cc:dd:ee:02"]["hostname"] == "printer"
+
+    # Later refresh reports "*": the known hostname must survive.
+    # Reset the cached boot time first — with homeassistant.util.dt mocked out,
+    # the drift comparison on a second refresh would operate on MagicMocks.
+    coordinator._boot_time = None
+    mock_client.get_all_data.return_value = _data("*", "*")
+    await coordinator._async_update_data()
+
+    assert coordinator._device_history["00:bb:cc:dd:ee:01"]["hostname"] == "device1"
+    assert coordinator._device_history["00:bb:cc:dd:ee:02"]["hostname"] == "printer"
+
+
+@pytest.mark.asyncio
+async def test_device_history_never_stores_placeholder_hostname() -> None:
+    """A device first seen as "*" is stored without a hostname, not with "*"."""
+    hass = MagicMock()
+    hass.loop = MagicMock()
+    hass.loop.time = MagicMock(return_value=123456789.0)
+
+    config_entry = MagicMock()
+    config_entry.options = {}
+    config_entry.data = {"host": "192.168.1.1"}
+    config_entry.entry_id = "test_entry"
+
+    mock_client = AsyncMock()
+    mock_client.connected = True
+    mock_client.get_all_data.return_value = OpenWrtData(
+        system_resources=SystemResources(uptime=100),
+        connected_devices=[
+            ConnectedDevice(
+                mac="00:bb:cc:dd:ee:01",
+                hostname="*",
+                interface="br-lan",
+                is_wireless=True,
+            ),
+        ],
+        dhcp_leases=[
+            DhcpLease(mac="00:bb:cc:dd:ee:02", hostname="*", ip="192.168.1.11"),
+        ],
+        network_interfaces=[],
+        wireless_interfaces=[],
+    )
+
+    with patch("custom_components.openwrt.coordinator.storage.Store") as mock_store:
+        mock_store.return_value.async_load = AsyncMock(return_value={})
+        mock_store.return_value.async_save = AsyncMock()
+        coordinator = OpenWrtDataCoordinator(hass, config_entry, mock_client)
+
+    await coordinator._async_update_data()
+
+    assert coordinator._device_history["00:bb:cc:dd:ee:01"]["hostname"] == ""
+    assert coordinator._device_history["00:bb:cc:dd:ee:02"]["hostname"] == ""
+
+
+@pytest.mark.asyncio
+async def test_options_flow_falls_back_to_mac_for_placeholder_hostname() -> None:
+    """A "*" hostname must render as the MAC, not as a literal asterisk."""
+    flow = _make_options_flow(
+        all_connected_devices=[
+            ConnectedDevice(mac="00:BB:CC:DD:EE:02", hostname="*"),
+        ],
+        device_history={},
+        tracked=[],
+    )
+
+    with patch("custom_components.openwrt.config_flow.selector") as mock_selector:
+        await flow.async_step_options_select_devices()
+
+    options = _tracked_device_options(mock_selector.SelectSelectorConfig)
+    assert options["00:bb:cc:dd:ee:02"] == "00:BB:CC:DD:EE:02 (00:BB:CC:DD:EE:02)"


### PR DESCRIPTION
## Description

The tracked-devices multi-select in the **options** flow renders with no selectable devices, so you can never add a device to the tracked set after initial setup. Once selective tracking is enabled, the set is effectively frozen — the only escape is to remove and re-add the config entry.

### Root cause — a chicken-and-egg between two pieces

**1. `coordinator.py` — `_async_filter_and_track_devices()`**

The loop builds two lists: `all_devices` (everything passing the internal filters) and `filtered_devices` (additionally requires whitelist membership). The whitelist check `continue`s *before* the history-insert block, so only whitelisted devices are ever written to `_device_history`:

```python
# Filter by whitelist if configured
if whitelist and mac not in whitelist:
    continue

filtered_devices.append(device)
...
if mac not in self._device_history:
    self._device_history[mac] = {...}
```

**2. `config_flow.py` — `OpenWrtOptionsFlow.async_step_options_select_devices()`**

Built its candidate list from `coordinator._device_history`.

Because history is already whitelist-filtered, the candidate list **equals the already-selected set**. A multi-select only offers *unselected* options, so the dropdown is empty and the selection can never grow.

The **initial setup** flow is unaffected — `async_step_selective_tracking()` fetches candidates live from the router via `client.get_connected_devices()` + `client.get_dhcp_leases()`. Only the options flow reads from history. That asymmetry is the bug.

### Evidence

Verified on a live 3-router (multi-AP) install running v2.4.3. For every config entry the selected set and the history set are identical, leaving zero selectable options:

| Config entry | Devices seen by router | Tracked | In `_device_history` | Selectable in options flow |
|---|---|---|---|---|
| Router 1 | 54 | 7 | 7 | **0** |
| Router 2 | 44 | 1 | 1 | **0** |
| Router 3 | 32 | 1 | 1 | **0** |

Confirmed still present in v2.4.4 and current `main`.

## The fix

Source candidates from `coordinator.data.all_connected_devices`, which is explicitly *not* whitelist-filtered (per the `all_devices` / `filtered_devices` comment in the coordinator), unioned with `_device_history` so devices that are currently offline but previously seen stay selectable.

This needs no extra router round-trip — the coordinator data is already in memory and current, unlike the setup flow which opens a fresh connection.

Two smaller things included:

- **Currently selected MACs are always kept as options.** Previously a tracked device the coordinator had not seen could leave the stored value outside the option list, making it an invalid selection.
- **`_device_history` now records the last known hostname.** It only stored `initially_seen` / `last_seen` / `is_wireless`, so options rendered as `aa:bb:cc:dd:ee:ff (aa:bb:cc:dd:ee:ff)`. Devices from `all_connected_devices` carry real hostnames for online devices, and history now carries them for offline ones. This also fixes MQTT discovery, which already read `hist_data.get("hostname") or mac` in `_async_discovery_loop()` but never found one — so MQTT devices were being announced under their MAC.

The MAC stays the option `value` throughout, since the whitelist matches on lowercased MAC.

### On folding in DHCP leases (for parity with the setup flow)

I looked at this and deliberately left it out. `coordinator.data.dhcp_leases` is **also** whitelist-filtered, a few lines below the device loop:

```python
if whitelist:
    data.dhcp_leases = [l for l in data.dhcp_leases if l.mac and l.mac.lower() in whitelist]
```

so it has the same chicken-and-egg problem and would contribute nothing beyond the already-selected set. Exposing an unfiltered copy is not a one-liner either: that whitelist filter runs *before* the loop that strips internal interfaces (`veth`, `wlanX`, …), so a raw copy would pollute the dropdown with router-internal entries. Doing it properly means restructuring the lease loop into `all_leases` / `filtered_leases` the same way the device loop was split.

The residual gap is a device that has a DHCP lease but never appears in the connected-device list and is not already tracked. Happy to follow up with the lease-loop split if you'd like it in this PR or a separate one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Tests
- [ ] Tested on actual hardware (behaviour diagnosed on live v2.4.3 hardware — 3× OpenWrt routers, multi-AP — but the patched build has not yet been deployed there)

Four tests added to `tests/test_selective_tracking.py`:

- `test_options_flow_offers_untracked_devices` — the core regression test: 3 devices connected, 1 whitelisted and in history; asserts all 3 are offered and that the hostname label comes from the live device list.
- `test_options_flow_keeps_offline_and_selected_devices` — offline history devices keep their stored hostname, stored selections remain valid options, non-dict history entries are skipped.
- `test_options_flow_without_coordinator_data` — form still builds when the coordinator has not completed a refresh.
- `test_device_history_records_hostname` — hostnames land in history from both connected devices and DHCP leases.

Verified these are genuine regression tests: 3 of the 4 fail against unpatched `main` and pass with the change.

Full suite: `265 passed`. `tests/test_device_tracker.py::test_device_tracker_stale_arp_presence` fails and `tests/test_gps_location.py` errors on collection, but both reproduce on a clean checkout of `main` at 19fb3d1 without this patch — pre-existing and unrelated.

## Checklist

- [x] My code follows the style guidelines of this project (`ruff check` and `ruff format --check` clean)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (no user-facing docs describe this step)
- [x] New and existing unit tests pass locally with my changes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device selection now includes all currently connected devices, including those not previously tracked.
  * Previously selected and offline devices remain available for selection.
  * Device history now preserves readable hostnames for offline devices and MQTT discovery.

* **Bug Fixes**
  * Improved handling of incomplete device history and missing device data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->