### PR TITLE
feat(wireless): expose physical radios and radio-level transmit power

### DIFF
--- a/.github/scripts/check_private_data.py
+++ b/.github/scripts/check_private_data.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Reject private installation data from newly added Git lines."""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+IPV4_RE = re.compile(r"(?<![\d.])(?:\d{1,3}\.){3}\d{1,3}(?![\d.])")
+MAC_RE = re.compile(r"(?i)(?<![0-9a-f])(?:[0-9a-f]{2}:){5}[0-9a-f]{2}(?![0-9a-f])")
+SECRET_RES = (
+    re.compile(r"(?i)\b(?:bearer|token)\s+[a-z0-9._~-]{20,}"),
+    re.compile(r"\b(?:ghp|github_pat|sk-proj|sk)-[A-Za-z0-9_-]{16,}"),
+    re.compile(r"\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}"),
+)
+SYNTHETIC_MAC_RES = (
+    re.compile(r"(?i)^00:00:00:00:00:00$"),
+    re.compile(r"(?i)^00:11:22:33:44:[0-9a-f]{2}$"),
+    re.compile(r"(?i)^02:00:00:00:00:[0-9a-f]{2}$"),
+    re.compile(r"(?i)^11:22:33:44:55:66$"),
+    re.compile(r"(?i)^aa:bb:cc:dd:ee:ff$"),
+)
+PRIVATE_IPV4_NETWORKS = (
+    ipaddress.ip_network("10" + ".0.0.0/8"),
+    ipaddress.ip_network("172" + ".16.0.0/12"),
+    ipaddress.ip_network("192" + ".168.0.0/16"),
+)
+
+
+@dataclass(frozen=True)
+class AddedLine:
+    """One added line and its destination location."""
+
+    path: str
+    line_number: int
+    text: str
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A privacy category at a source location."""
+
+    path: str
+    line_number: int
+    category: str
+
+
+def _run_git(args: list[str]) -> str:
+    """Run Git without interpreting repository content as shell syntax."""
+    result = subprocess.run(
+        ["git", "-c", f"safe.directory={Path.cwd().resolve().as_posix()}", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    return result.stdout
+
+
+def _added_lines(diff: str) -> list[AddedLine]:
+    """Extract destination lines from a zero-context unified diff."""
+    path = ""
+    destination_line = 0
+    added: list[AddedLine] = []
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[6:]
+            continue
+        if line.startswith("@@"):
+            match = re.search(r"\+(\d+)(?:,\d+)?", line)
+            destination_line = int(match.group(1)) if match else 0
+            continue
+        if not path or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            added.append(AddedLine(path, destination_line, line[1:]))
+            destination_line += 1
+        elif not line.startswith("-"):
+            destination_line += 1
+    return added
+
+
+def _load_private_patterns() -> tuple[re.Pattern[str], ...]:
+    """Load optional local and CI-only installation denylist patterns."""
+    raw_patterns: list[str] = []
+    local_file = Path(".private-data-patterns")
+    if local_file.is_file():
+        raw_patterns.extend(local_file.read_text(encoding="utf-8").splitlines())
+    raw_patterns.extend(os.environ.get("PRIVATE_DATA_PATTERNS", "").splitlines())
+    return tuple(
+        re.compile(pattern, re.IGNORECASE)
+        for raw in raw_patterns
+        if (pattern := raw.strip()) and not pattern.startswith("#")
+    )
+
+
+def _is_synthetic_mac(value: str) -> bool:
+    return any(pattern.fullmatch(value) for pattern in SYNTHETIC_MAC_RES)
+
+
+def find_violations(
+    lines: Iterable[AddedLine],
+    private_patterns: Iterable[re.Pattern[str]],
+) -> list[Violation]:
+    """Return privacy violations without retaining or printing their values."""
+    violations: set[Violation] = set()
+    patterns = tuple(private_patterns)
+    for line in lines:
+        for value in IPV4_RE.findall(line.text):
+            try:
+                address = ipaddress.ip_address(value)
+            except ValueError:
+                continue
+            if any(address in network for network in PRIVATE_IPV4_NETWORKS):
+                violations.add(Violation(line.path, line.line_number, "private IPv4"))
+        for value in MAC_RE.findall(line.text):
+            if not _is_synthetic_mac(value):
+                violations.add(Violation(line.path, line.line_number, "MAC address"))
+        if any(pattern.search(line.text) for pattern in SECRET_RES):
+            violations.add(Violation(line.path, line.line_number, "credential-like value"))
+        if any(pattern.search(line.text) for pattern in patterns):
+            violations.add(Violation(line.path, line.line_number, "installation denylist"))
+    return sorted(violations, key=lambda item: (item.path, item.line_number, item.category))
+
+
+def _self_test() -> None:
+    """Verify detection without embedding usable private fixture values."""
+    private_ip = "192" + ".168.42.7"
+    private_mac = "7c" + ":10:c9:12:34:56"
+    lines = [
+        AddedLine("sample.py", 1, f"host = '{private_ip}'"),
+        AddedLine("sample.py", 2, f"mac = '{private_mac}'"),
+        AddedLine("sample.py", 3, "host = '192.0.2.10'"),
+        AddedLine("sample.py", 4, "mac = '02:00:00:00:00:01'"),
+    ]
+    categories = {item.category for item in find_violations(lines, ())}
+    if categories != {"private IPv4", "MAC address"}:
+        raise RuntimeError("privacy scanner self-test failed")
+
+
+def main() -> int:
+    """Scan staged or branch-added lines."""
+    parser = argparse.ArgumentParser()
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--staged", action="store_true")
+    source.add_argument("--base")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        _self_test()
+    if args.staged:
+        diff = _run_git(["diff", "--cached", "--unified=0", "--no-ext-diff"])
+    elif args.base:
+        diff = _run_git(["diff", "--unified=0", "--no-ext-diff", args.base])
+    else:
+        parser.error("one of --staged or --base is required")
+
+    violations = find_violations(_added_lines(diff), _load_private_patterns())
+    for violation in violations:
+        print(f"{violation.path}:{violation.line_number}: {violation.category}")
+    if violations:
+        print(f"Private-data check failed with {len(violations)} finding(s).")
+        return 1
+    print("Private-data check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_private_data.py
+++ b/.github/scripts/check_private_data.py
@@ -151,12 +151,37 @@ def _self_test() -> None:
         raise RuntimeError("privacy scanner self-test failed")
 
 
+def _resolve_github_base(
+    event_name: str,
+    before: str,
+    default_branch: str,
+) -> str:
+    """Resolve the complete branch base for a GitHub Actions scan."""
+    if event_name == "push" and before and set(before) != {"0"}:
+        return before
+    if not default_branch:
+        raise ValueError("default branch is required")
+    remote_ref = f"refs/remotes/origin/{default_branch}"
+    _run_git(
+        [
+            "fetch",
+            "--no-tags",
+            "origin",
+            f"{default_branch}:{remote_ref}",
+        ]
+    )
+    return _run_git(["merge-base", "HEAD", remote_ref]).strip()
+
+
 def main() -> int:
     """Scan staged or branch-added lines."""
     parser = argparse.ArgumentParser()
     source = parser.add_mutually_exclusive_group()
     source.add_argument("--staged", action="store_true")
     source.add_argument("--base")
+    source.add_argument("--github-event-name")
+    parser.add_argument("--github-before", default="")
+    parser.add_argument("--default-branch", default="")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
 
@@ -166,8 +191,18 @@ def main() -> int:
         diff = _run_git(["diff", "--cached", "--unified=0", "--no-ext-diff"])
     elif args.base:
         diff = _run_git(["diff", "--unified=0", "--no-ext-diff", args.base])
+    elif args.github_event_name:
+        try:
+            base = _resolve_github_base(
+                args.github_event_name,
+                args.github_before,
+                args.default_branch,
+            )
+        except ValueError as err:
+            parser.error(str(err))
+        diff = _run_git(["diff", "--unified=0", "--no-ext-diff", base])
     else:
-        parser.error("one of --staged or --base is required")
+        parser.error("one of --staged, --base, or --github-event-name is required")
 
     violations = find_violations(_added_lines(diff), _load_private_patterns())
     for violation in violations:

--- a/.github/scripts/check_private_data.py
+++ b/.github/scripts/check_private_data.py
@@ -124,10 +124,16 @@ def find_violations(
             if not _is_synthetic_mac(value):
                 violations.add(Violation(line.path, line.line_number, "MAC address"))
         if any(pattern.search(line.text) for pattern in SECRET_RES):
-            violations.add(Violation(line.path, line.line_number, "credential-like value"))
+            violations.add(
+                Violation(line.path, line.line_number, "credential-like value")
+            )
         if any(pattern.search(line.text) for pattern in patterns):
-            violations.add(Violation(line.path, line.line_number, "installation denylist"))
-    return sorted(violations, key=lambda item: (item.path, item.line_number, item.category))
+            violations.add(
+                Violation(line.path, line.line_number, "installation denylist")
+            )
+    return sorted(
+        violations, key=lambda item: (item.path, item.line_number, item.category)
+    )
 
 
 def _self_test() -> None:

--- a/.github/workflows/fork-feature-validation.yml
+++ b/.github/workflows/fork-feature-validation.yml
@@ -28,11 +28,11 @@ jobs:
 
       - name: Check newly added data
         run: |
-          BASE_SHA="${{ github.event.before }}"
-          if [[ "${{ github.event_name }}" != "push" || "$BASE_SHA" =~ ^0+$ ]]; then
-            BASE_SHA="$(git rev-parse HEAD^)"
-          fi
-          python .github/scripts/check_private_data.py --self-test --base "$BASE_SHA"
+          python .github/scripts/check_private_data.py \
+            --self-test \
+            --github-event-name "${{ github.event_name }}" \
+            --github-before "${{ github.event.before }}" \
+            --default-branch "${{ github.event.repository.default_branch }}"
 
       - name: Install validation dependencies
         run: |

--- a/.github/workflows/fork-feature-validation.yml
+++ b/.github/workflows/fork-feature-validation.yml
@@ -29,7 +29,11 @@ jobs:
         env:
           PRIVATE_DATA_PATTERNS: ${{ secrets.PRIVATE_DATA_PATTERNS }}
         run: |
-          python .github/scripts/check_private_data.py --self-test --base origin/main
+          BASE_SHA="${{ github.event.before }}"
+          if [[ "${{ github.event_name }}" != "push" || "$BASE_SHA" =~ ^0+$ ]]; then
+            BASE_SHA="$(git rev-parse HEAD^)"
+          fi
+          python .github/scripts/check_private_data.py --self-test --base "$BASE_SHA"
 
       - name: Install validation dependencies
         run: |

--- a/.github/workflows/fork-feature-validation.yml
+++ b/.github/workflows/fork-feature-validation.yml
@@ -1,0 +1,54 @@
+name: Fork Feature Validation
+
+on:
+  push:
+    branches:
+      - 'codex/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fork-feature-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v7.0.0
+        with:
+          python-version: '3.13'
+
+      - name: Check newly added data
+        env:
+          PRIVATE_DATA_PATTERNS: ${{ secrets.PRIVATE_DATA_PATTERNS }}
+        run: |
+          python .github/scripts/check_private_data.py --self-test --base origin/main
+
+      - name: Install validation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff mypy==1.18.2 pyyaml pytest pytest-asyncio pytest-cov homeassistant paramiko aiohttp pytest-homeassistant-custom-component beautifulsoup4
+
+      - name: Lint
+        run: ruff check .
+
+      - name: Type check
+        run: >-
+          mypy --follow-imports=silent
+          custom_components/openwrt/api/ssh/network.py
+          custom_components/openwrt/api/ubus/network.py
+          custom_components/openwrt/api/ubus/wireless.py
+          custom_components/openwrt/coordinator.py
+          custom_components/openwrt/helpers/__init__.py
+          custom_components/openwrt/number.py
+          custom_components/openwrt/switch.py
+
+      - name: Test
+        run: PYTHONPATH=. pytest --cov=custom_components.openwrt --cov-report=term-missing

--- a/.github/workflows/fork-feature-validation.yml
+++ b/.github/workflows/fork-feature-validation.yml
@@ -20,14 +20,13 @@ jobs:
       - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-python@v7.0.0
         with:
           python-version: '3.13'
 
       - name: Check newly added data
-        env:
-          PRIVATE_DATA_PATTERNS: ${{ secrets.PRIVATE_DATA_PATTERNS }}
         run: |
           BASE_SHA="${{ github.event.before }}"
           if [[ "${{ github.event_name }}" != "push" || "$BASE_SHA" =~ ^0+$ ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ celerybeat.pid
 
 # Environments
 .env
+.private-data-patterns
 .venv
 env/
 venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,17 @@
 repos:
+  - repo: local
+    hooks:
+      - id: private-data
+        name: Reject private installation data
+        entry: python .github/scripts/check_private_data.py --self-test --staged
+        language: system
+        pass_filenames: false
+      - id: pytest
+        name: Run unit tests
+        entry: python -m pytest -q -p no:cacheprovider
+        language: system
+        pass_filenames: false
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.5
     hooks:

--- a/custom_components/openwrt/api/base.py
+++ b/custom_components/openwrt/api/base.py
@@ -144,6 +144,7 @@ class WirelessInterface:
     encryption: str = ""
     clients_count: int = 0
     enabled: bool = True
+    interface_enabled: bool = True
     up: bool = False
     radio: str = ""
     radio_enabled: bool = True
@@ -211,6 +212,11 @@ class WirelessInterface:
             if 5.9 < freq <= 7.2:
                 return "6 GHz"
         return ""
+
+    @staticmethod
+    def _uci_disabled(value: Any) -> bool:
+        """Return whether a UCI disabled option is active."""
+        return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
     def __post_init__(self) -> None:
         """Post-process wireless data."""
@@ -1407,6 +1413,23 @@ class OpenWrtClient(abc.ABC):
     async def set_radio_enabled(self, radio: str, enabled: bool) -> bool:
         """Physically enable or disable a wireless radio."""
         return await self.set_wireless_enabled(radio, enabled)
+
+    async def set_wireless_network_enabled(
+        self,
+        interface: str,
+        radio: str,
+        enabled: bool,
+        *,
+        disable_radio: bool,
+    ) -> bool:
+        """Set an SSID and coordinate its physical radio."""
+        if enabled and not await self.set_radio_enabled(radio, True):
+            return False
+        if not await self.set_wireless_enabled(interface, enabled):
+            return False
+        if disable_radio:
+            return await self.set_radio_enabled(radio, False)
+        return True
 
     async def manage_interface(self, name: str, action: str) -> bool:
         """Manage a network interface (up/down/reconnect)."""

--- a/custom_components/openwrt/api/base.py
+++ b/custom_components/openwrt/api/base.py
@@ -146,6 +146,7 @@ class WirelessInterface:
     enabled: bool = True
     up: bool = False
     radio: str = ""
+    radio_enabled: bool = True
     htmode: str = ""
     txpower: int = 0
     txpower_offset: int = 0
@@ -1402,6 +1403,10 @@ class OpenWrtClient(abc.ABC):
     async def set_wireless_enabled(self, interface: str, enabled: bool) -> bool:
         """Enable or disable a wireless interface."""
         return False
+
+    async def set_radio_enabled(self, radio: str, enabled: bool) -> bool:
+        """Physically enable or disable a wireless radio."""
+        return await self.set_wireless_enabled(radio, enabled)
 
     async def manage_interface(self, name: str, action: str) -> bool:
         """Manage a network interface (up/down/reconnect)."""

--- a/custom_components/openwrt/api/luci_rpc/network.py
+++ b/custom_components/openwrt/api/luci_rpc/network.py
@@ -5,6 +5,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import shlex
 
 from ..base import (
     LldpNeighbor,
@@ -123,12 +124,16 @@ class LuciRpcNetworkMixin:
                                 continue
 
                             iface_config = iface.get("config", {})
+                            iface_disabled = WirelessInterface._uci_disabled(
+                                iface_config.get("disabled", False)
+                            )
                             wifi = WirelessInterface(
                                 name=iface_name,
                                 ssid=iface_config.get("ssid", ""),
                                 mode=iface_config.get("mode", ""),
                                 encryption=iface_config.get("encryption", ""),
                                 enabled=not radio_data.get("disabled", False),
+                                interface_enabled=not iface_disabled,
                                 up=radio_data.get("up", False),
                                 radio=radio_name,
                                 radio_enabled=not radio_data.get("disabled", False),
@@ -185,6 +190,7 @@ class LuciRpcNetworkMixin:
                                 mode=sect_data.get("mode", ""),
                                 encryption=sect_data.get("encryption", ""),
                                 enabled=not (radio_disabled or iface_disabled),
+                                interface_enabled=not iface_disabled,
                                 up=not (radio_disabled or iface_disabled),
                                 radio=radio_name,
                                 radio_enabled=not radio_disabled,
@@ -688,6 +694,30 @@ class LuciRpcNetworkMixin:
                 "wifi reload"
             )
             await self.execute_command(cmd)
+            self._last_full_poll = 0
+            return True
+        except Exception:
+            return False
+
+    async def set_wireless_network_enabled(
+        self,
+        interface: str,
+        radio: str,
+        enabled: bool,
+        *,
+        disable_radio: bool,
+    ) -> bool:
+        """Set an SSID and its radio in one UCI transaction."""
+        try:
+            assignments = []
+            if enabled:
+                assignments.append(f"wireless.{radio}.disabled=0")
+            assignments.append(f"wireless.{interface}.disabled={0 if enabled else 1}")
+            if disable_radio:
+                assignments.append(f"wireless.{radio}.disabled=1")
+            commands = [f"uci set {shlex.quote(value)}" for value in assignments]
+            commands.extend(("uci commit wireless", "wifi reload"))
+            await self.execute_command(" && ".join(commands))
             self._last_full_poll = 0
             return True
         except Exception:

--- a/custom_components/openwrt/api/luci_rpc/network.py
+++ b/custom_components/openwrt/api/luci_rpc/network.py
@@ -151,56 +151,97 @@ class LuciRpcNetworkMixin:
                             if ifname and ifname != iface_name:
                                 iface_names.add(ifname)
             except Exception as err:
-                _LOGGER.debug(
-                    "network.wireless status failed via LuCI, trying UCI: %s", err
-                )
-                try:
-                    uci_wireless_str = await self.execute_command("uci export wireless")
-                    if uci_wireless_str:
-                        sections: dict[str, dict[str, str]] = {}
-                        current_section = ""
-                        for line in uci_wireless_str.splitlines():
-                            line = line.strip()
-                            if line.startswith("config"):
-                                parts = line.split()
-                                if len(parts) >= 3:
-                                    current_section = parts[2].strip("'\"")
-                                    sections[current_section] = {".type": parts[1]}
-                            elif line.startswith("option") and current_section:
-                                parts = line.split(None, 2)
-                                if len(parts) >= 3:
-                                    sections[current_section][parts[1]] = parts[
-                                        2
-                                    ].strip("'\"")
+                _LOGGER.debug("network.wireless status failed via LuCI: %s", err)
 
-                        for sect_name, sect_data in sections.items():
-                            if sect_data.get(".type") != "wifi-iface":
-                                continue
+        # network.wireless omits its interface list when a physical radio is
+        # disabled. Always supplement the runtime response with UCI so the
+        # configured radio and SSID entities remain present and can be turned
+        # back on from Home Assistant.
+        if self.packages.wireless is not False:
+            try:
+                uci_wireless_str = await self.execute_command("uci export wireless")
+                if uci_wireless_str:
+                    sections: dict[str, dict[str, str]] = {}
+                    current_section = ""
+                    for line in uci_wireless_str.splitlines():
+                        line = line.strip()
+                        if line.startswith("config"):
+                            parts = line.split()
+                            if len(parts) >= 3:
+                                current_section = parts[2].strip("'\"")
+                                sections[current_section] = {".type": parts[1]}
+                        elif line.startswith("option") and current_section:
+                            parts = line.split(None, 2)
+                            if len(parts) >= 3:
+                                sections[current_section][parts[1]] = parts[2].strip(
+                                    "'\""
+                                )
 
-                            iface_name = sect_data.get("ifname") or sect_name
-                            radio_name = sect_data.get("device", "")
-                            radio_disabled = (
-                                sections.get(radio_name, {}).get("disabled", "0") == "1"
+                    by_section = {
+                        wifi.section: wifi for wifi in interfaces if wifi.section
+                    }
+                    for sect_name, sect_data in sections.items():
+                        if sect_data.get(".type") != "wifi-iface":
+                            continue
+
+                        radio_name = sect_data.get("device", "")
+                        radio_config = sections.get(radio_name, {})
+                        radio_disabled = WirelessInterface._uci_disabled(
+                            radio_config.get("disabled", "0")
+                        )
+                        iface_disabled = WirelessInterface._uci_disabled(
+                            sect_data.get("disabled", "0")
+                        )
+                        configured_enabled = not (radio_disabled or iface_disabled)
+
+                        existing = by_section.get(sect_name)
+                        if existing is not None:
+                            existing.radio = existing.radio or radio_name
+                            existing.radio_enabled = not radio_disabled
+                            existing.interface_enabled = not iface_disabled
+                            existing.enabled = configured_enabled
+                            existing.up = existing.up and configured_enabled
+                            existing.ssid = existing.ssid or sect_data.get("ssid", "")
+                            existing.mode = existing.mode or sect_data.get("mode", "")
+                            existing.encryption = existing.encryption or sect_data.get(
+                                "encryption", ""
                             )
-                            iface_disabled = sect_data.get("disabled", "0") == "1"
-
-                            wifi = WirelessInterface(
-                                name=iface_name,
-                                ssid=sect_data.get("ssid", ""),
-                                mode=sect_data.get("mode", ""),
-                                encryption=sect_data.get("encryption", ""),
-                                enabled=not (radio_disabled or iface_disabled),
-                                interface_enabled=not iface_disabled,
-                                up=not (radio_disabled or iface_disabled),
-                                radio=radio_name,
-                                radio_enabled=not radio_disabled,
-                                hwmode=sections.get(radio_name, {}).get("hwmode", ""),
-                                section=sect_name,
+                            existing.hwmode = existing.hwmode or radio_config.get(
+                                "hwmode", ""
                             )
-                            interfaces.append(wifi)
-                            iface_names.add(iface_name)
-                except Exception as e:
-                    _LOGGER.debug("UCI wireless fallback failed via LuCI: %s", e)
+                            existing.band = (
+                                existing.band
+                                or WirelessInterface._band_from_raw(
+                                    radio_config.get("band", "")
+                                    or radio_config.get("hwmode", "")
+                                )
+                            )
+                            continue
+
+                        iface_name = sect_data.get("ifname") or sect_name
+                        wifi = WirelessInterface(
+                            name=iface_name,
+                            ssid=sect_data.get("ssid", ""),
+                            mode=sect_data.get("mode", ""),
+                            encryption=sect_data.get("encryption", ""),
+                            enabled=configured_enabled,
+                            interface_enabled=not iface_disabled,
+                            up=configured_enabled,
+                            radio=radio_name,
+                            radio_enabled=not radio_disabled,
+                            hwmode=radio_config.get("hwmode", ""),
+                            section=sect_name,
+                            ifname=sect_data.get("ifname", ""),
+                            band=WirelessInterface._band_from_raw(
+                                radio_config.get("band", "")
+                                or radio_config.get("hwmode", "")
+                            ),
+                        )
+                        interfaces.append(wifi)
+                        by_section[sect_name] = wifi
+                        iface_names.add(iface_name)
+            except Exception as err:
+                _LOGGER.debug("UCI wireless supplement failed via LuCI: %s", err)
 
         # 2. Supplement/Fallback: iwinfo devices
         iw_devs = set()
@@ -340,8 +381,7 @@ class LuciRpcNetworkMixin:
             )
             if is_ghost_name and (
                 not wifi.ssid
-                or wifi.ssid == "OpenWrt"
-                or not wifi.mac_address
+                or (wifi.ssid == "OpenWrt" and not wifi.mac_address)
                 or wifi.mac_address == "00:00:00:00:00:00"
             ):
                 _LOGGER.debug(

--- a/custom_components/openwrt/api/luci_rpc/network.py
+++ b/custom_components/openwrt/api/luci_rpc/network.py
@@ -131,6 +131,7 @@ class LuciRpcNetworkMixin:
                                 enabled=not radio_data.get("disabled", False),
                                 up=radio_data.get("up", False),
                                 radio=radio_name,
+                                radio_enabled=not radio_data.get("disabled", False),
                                 hwmode=radio_data.get("config", {}).get("hwmode", ""),
                                 section=section,
                                 ifname=ifname,
@@ -186,6 +187,7 @@ class LuciRpcNetworkMixin:
                                 enabled=not (radio_disabled or iface_disabled),
                                 up=not (radio_disabled or iface_disabled),
                                 radio=radio_name,
+                                radio_enabled=not radio_disabled,
                                 hwmode=sections.get(radio_name, {}).get("hwmode", ""),
                                 section=sect_name,
                             )

--- a/custom_components/openwrt/api/ssh/network.py
+++ b/custom_components/openwrt/api/ssh/network.py
@@ -164,8 +164,9 @@ class SshNetworkMixin:
         except Exception as err:
             _LOGGER.debug("network.wireless status failed via SSH: %s", err)
 
-        # 2. UCI fallback if no interfaces found via ubus
-        if not interfaces:
+        # 2. Always supplement runtime data with UCI. OpenWrt omits disabled
+        # interfaces (and all interfaces of a disabled radio) from runtime status.
+        if self.packages.wireless is not False:
             try:
                 uci_wireless_str = await self._exec("uci export wireless 2>/dev/null")
                 if uci_wireless_str:
@@ -185,42 +186,75 @@ class SshNetworkMixin:
                                     "'\""
                                 )
 
+                    by_section = {
+                        wifi.section: wifi for wifi in interfaces if wifi.section
+                    }
                     for sect_name, sect_data in sections.items():
                         if sect_data.get(".type") != "wifi-iface":
                             continue
 
                         iface_name = sect_data.get("ifname") or sect_name
                         radio_name = sect_data.get("device", "")
-                        radio_disabled = (
-                            sections.get(radio_name, {}).get("disabled", "0") == "1"
+                        radio_config = sections.get(radio_name, {})
+                        radio_disabled = WirelessInterface._uci_disabled(
+                            radio_config.get("disabled", "0")
                         )
-                        iface_disabled = sect_data.get("disabled", "0") == "1"
+                        iface_disabled = WirelessInterface._uci_disabled(
+                            sect_data.get("disabled", "0")
+                        )
+                        configured_enabled = not (radio_disabled or iface_disabled)
 
-                        ifname_val = sect_data.get("ifname")
-                        is_disabled = radio_disabled or iface_disabled
+                        existing = by_section.get(sect_name)
+                        if existing is not None:
+                            existing.radio = existing.radio or radio_name
+                            existing.radio_enabled = not radio_disabled
+                            existing.interface_enabled = not iface_disabled
+                            existing.enabled = configured_enabled
+                            existing.up = existing.up and configured_enabled
+                            existing.ssid = existing.ssid or sect_data.get("ssid", "")
+                            existing.mode = existing.mode or sect_data.get("mode", "")
+                            existing.encryption = existing.encryption or sect_data.get(
+                                "encryption", ""
+                            )
+                            existing.hwmode = existing.hwmode or radio_config.get(
+                                "hwmode", ""
+                            )
+                            existing.band = (
+                                existing.band
+                                or WirelessInterface._band_from_raw(
+                                    radio_config.get("band", "")
+                                    or radio_config.get("hwmode", "")
+                                )
+                            )
+                            continue
 
                         wifi = WirelessInterface(
                             name=iface_name,
                             ssid=sect_data.get("ssid", ""),
                             mode=sect_data.get("mode", ""),
                             encryption=sect_data.get("encryption", ""),
-                            enabled=not is_disabled,
+                            enabled=configured_enabled,
                             interface_enabled=not iface_disabled,
-                            up=not is_disabled,
+                            up=configured_enabled,
                             radio=radio_name,
                             radio_enabled=not radio_disabled,
-                            hwmode=sections.get(radio_name, {}).get("hwmode", ""),
+                            band=WirelessInterface._band_from_raw(
+                                radio_config.get("band", "")
+                                or radio_config.get("hwmode", "")
+                            ),
+                            hwmode=radio_config.get("hwmode", ""),
                             section=sect_name,
-                            ifname=ifname_val or "",
+                            ifname=sect_data.get("ifname", ""),
                         )
                         interfaces.append(wifi)
+                        by_section[sect_name] = wifi
                         iface_names.add(iface_name)
                         if sect_name and sect_name != iface_name:
                             iface_names.add(sect_name)
-                        if ifname_val and ifname_val != iface_name:
-                            iface_names.add(ifname_val)
+                        if wifi.ifname and wifi.ifname != iface_name:
+                            iface_names.add(wifi.ifname)
             except Exception as e:
-                _LOGGER.debug("UCI wireless fallback failed via SSH: %s", e)
+                _LOGGER.debug("UCI wireless supplement failed via SSH: %s", e)
 
         # 3. Populate metrics via ubus iwinfo
         for wifi in interfaces:

--- a/custom_components/openwrt/api/ssh/network.py
+++ b/custom_components/openwrt/api/ssh/network.py
@@ -124,16 +124,19 @@ class SshNetworkMixin:
                         iface_disabled = WirelessInterface._uci_disabled(
                             config.get("disabled", False)
                         )
+                        radio_disabled = WirelessInterface._uci_disabled(
+                            radio_data.get("disabled", False)
+                        )
                         wifi = WirelessInterface(
                             name=iface_name,
                             ssid=config.get("ssid", ""),
                             mode=config.get("mode", ""),
                             encryption=config.get("encryption", ""),
-                            enabled=not radio_data.get("disabled", False),
+                            enabled=not (radio_disabled or iface_disabled),
                             interface_enabled=not iface_disabled,
                             up=radio_data.get("up", False),
                             radio=radio_name,
-                            radio_enabled=not radio_data.get("disabled", False),
+                            radio_enabled=not radio_disabled,
                             band=WirelessInterface._band_from_raw(
                                 radio_data.get("config", {}).get("band", "")
                                 or radio_data.get("config", {}).get("hwmode", "")
@@ -545,14 +548,22 @@ class SshNetworkMixin:
 
         return interfaces
 
+    async def _exec_wireless_mutation(self, commands: list[str]) -> bool:
+        """Execute wireless commands and preserve their remote exit status."""
+        command = " && ".join(commands)
+        output = await self._exec(f'{command}; printf "\\n__HA_RC__:%s" $?')
+        _prefix, marker, status = output.rpartition("__HA_RC__:")
+        return marker == "__HA_RC__:" and status.strip() == "0"
+
     async def set_wireless_enabled(self, interface: str, enabled: bool) -> bool:
         """Enable/disable a wireless interface."""
         try:
             action = "0" if enabled else "1"
             safe_val = shlex.quote(f"wireless.{interface}.disabled={action}")
-            await self._exec(f"uci set {safe_val}")
-            await self._exec("uci commit wireless")
-            await self._exec("wifi reload")
+            if not await self._exec_wireless_mutation(
+                [f"uci set {safe_val}", "uci commit wireless", "wifi reload"]
+            ):
+                return False
             self._last_full_poll = 0
             return True
         except Exception as err:
@@ -577,7 +588,8 @@ class SshNetworkMixin:
                 assignments.append(f"wireless.{radio}.disabled=1")
             commands = [f"uci set {shlex.quote(value)}" for value in assignments]
             commands.extend(("uci commit wireless", "wifi reload"))
-            await self._exec(" && ".join(commands))
+            if not await self._exec_wireless_mutation(commands):
+                return False
             self._last_full_poll = 0
             return True
         except Exception as err:

--- a/custom_components/openwrt/api/ssh/network.py
+++ b/custom_components/openwrt/api/ssh/network.py
@@ -129,6 +129,7 @@ class SshNetworkMixin:
                             enabled=not radio_data.get("disabled", False),
                             up=radio_data.get("up", False),
                             radio=radio_name,
+                            radio_enabled=not radio_data.get("disabled", False),
                             band=WirelessInterface._band_from_raw(
                                 radio_data.get("config", {}).get("band", "")
                                 or radio_data.get("config", {}).get("hwmode", "")
@@ -202,6 +203,7 @@ class SshNetworkMixin:
                             enabled=not is_disabled,
                             up=not is_disabled,
                             radio=radio_name,
+                            radio_enabled=not radio_disabled,
                             hwmode=sections.get(radio_name, {}).get("hwmode", ""),
                             section=sect_name,
                             ifname=ifname_val or "",

--- a/custom_components/openwrt/api/ssh/network.py
+++ b/custom_components/openwrt/api/ssh/network.py
@@ -121,12 +121,16 @@ class SshNetworkMixin:
                         if not iface_name or iface_name in iface_names:
                             continue
 
+                        iface_disabled = WirelessInterface._uci_disabled(
+                            config.get("disabled", False)
+                        )
                         wifi = WirelessInterface(
                             name=iface_name,
                             ssid=config.get("ssid", ""),
                             mode=config.get("mode", ""),
                             encryption=config.get("encryption", ""),
                             enabled=not radio_data.get("disabled", False),
+                            interface_enabled=not iface_disabled,
                             up=radio_data.get("up", False),
                             radio=radio_name,
                             radio_enabled=not radio_data.get("disabled", False),
@@ -201,6 +205,7 @@ class SshNetworkMixin:
                             mode=sect_data.get("mode", ""),
                             encryption=sect_data.get("encryption", ""),
                             enabled=not is_disabled,
+                            interface_enabled=not iface_disabled,
                             up=not is_disabled,
                             radio=radio_name,
                             radio_enabled=not radio_disabled,
@@ -208,14 +213,12 @@ class SshNetworkMixin:
                             section=sect_name,
                             ifname=ifname_val or "",
                         )
-                        # Only add if not explicitly disabled or if we have no other choice
-                        if not is_disabled:
-                            interfaces.append(wifi)
-                            iface_names.add(iface_name)
-                            if sect_name and sect_name != iface_name:
-                                iface_names.add(sect_name)
-                            if ifname_val and ifname_val != iface_name:
-                                iface_names.add(ifname_val)
+                        interfaces.append(wifi)
+                        iface_names.add(iface_name)
+                        if sect_name and sect_name != iface_name:
+                            iface_names.add(sect_name)
+                        if ifname_val and ifname_val != iface_name:
+                            iface_names.add(ifname_val)
             except Exception as e:
                 _LOGGER.debug("UCI wireless fallback failed via SSH: %s", e)
 
@@ -520,6 +523,31 @@ class SshNetworkMixin:
             return True
         except Exception as err:
             _LOGGER.exception("Failed to set wireless %s: %s", interface, err)
+            return False
+
+    async def set_wireless_network_enabled(
+        self,
+        interface: str,
+        radio: str,
+        enabled: bool,
+        *,
+        disable_radio: bool,
+    ) -> bool:
+        """Set an SSID and its radio in one UCI transaction."""
+        try:
+            assignments = []
+            if enabled:
+                assignments.append(f"wireless.{radio}.disabled=0")
+            assignments.append(f"wireless.{interface}.disabled={0 if enabled else 1}")
+            if disable_radio:
+                assignments.append(f"wireless.{radio}.disabled=1")
+            commands = [f"uci set {shlex.quote(value)}" for value in assignments]
+            commands.extend(("uci commit wireless", "wifi reload"))
+            await self._exec(" && ".join(commands))
+            self._last_full_poll = 0
+            return True
+        except Exception as err:
+            _LOGGER.exception("Failed to coordinate wireless network: %s", err)
             return False
 
     async def manage_interface(self, name: str, action: str) -> bool:

--- a/custom_components/openwrt/api/ubus/network.py
+++ b/custom_components/openwrt/api/ubus/network.py
@@ -22,6 +22,15 @@ UBUS_ID_AUTH = 1
 UBUS_ID_CALL = 2
 
 
+def _valid_txpower(value: Any) -> int:
+    """Return a positive dBm value, or zero when OpenWrt has no reading."""
+    try:
+        power = int(float(value))
+    except (TypeError, ValueError):
+        return 0
+    return power if power > 0 else 0
+
+
 class UbusNetworkMixin:
     """Network methods for UbusClient."""
 
@@ -90,7 +99,9 @@ class UbusNetworkMixin:
                                 ),
                                 htmode=radio_data.get("config", {}).get("htmode", ""),
                                 hwmode=radio_data.get("config", {}).get("hwmode", ""),
-                                txpower=radio_data.get("config", {}).get("txpower", 0),
+                                txpower=_valid_txpower(
+                                    radio_data.get("config", {}).get("txpower")
+                                ),
                                 mesh_id=iface_config.get("mesh_id", ""),
                                 mesh_fwding=iface_config.get("mesh_fwding", False),
                                 section=section,
@@ -147,6 +158,9 @@ class UbusNetworkMixin:
                                 or vals.get(radio_name, {}).get("hwmode", "")
                             ),
                             hwmode=vals.get(radio_name, {}).get("hwmode", ""),
+                            txpower=_valid_txpower(
+                                vals.get(radio_name, {}).get("txpower")
+                            ),
                             section=sect_name,
                             ifname=sect_data.get("ifname"),
                         )
@@ -218,6 +232,9 @@ class UbusNetworkMixin:
                         wifi.ssid = iwinfo.get("ssid", "")
                     wifi.mac_address = iwinfo.get("bssid", "").upper()
                     wifi.channel = iwinfo.get("channel", 0)
+                    reported_txpower = _valid_txpower(iwinfo.get("txpower"))
+                    if reported_txpower:
+                        wifi.txpower = reported_txpower
                     wifi.frequency = str(iwinfo.get("frequency", ""))
                     # Re-resolve band from frequency if not already set
                     if not wifi.band and wifi.frequency:

--- a/custom_components/openwrt/api/ubus/network.py
+++ b/custom_components/openwrt/api/ubus/network.py
@@ -263,8 +263,6 @@ class UbusNetworkMixin:
                     if q_val is not None and q_max:
                         wifi.quality = round((q_val / q_max) * 100, 1)
 
-                    if iwinfo.get("txpower") is not None:
-                        wifi.txpower = iwinfo["txpower"]
                     if iwinfo.get("txpower_offset") is not None:
                         wifi.txpower_offset = iwinfo["txpower_offset"]
 

--- a/custom_components/openwrt/api/ubus/network.py
+++ b/custom_components/openwrt/api/ubus/network.py
@@ -79,6 +79,7 @@ class UbusNetworkMixin:
                                 enabled=not radio_data.get("disabled", False),
                                 up=not radio_data.get("disabled", False),
                                 radio=radio_name,
+                                radio_enabled=not radio_data.get("disabled", False),
                                 band=WirelessInterface._band_from_raw(
                                     radio_data.get("config", {}).get("band", "")
                                     or radio_data.get("config", {}).get("hwmode", "")
@@ -135,6 +136,7 @@ class UbusNetworkMixin:
                             enabled=not (radio_disabled or iface_disabled),
                             up=not (radio_disabled or iface_disabled),
                             radio=radio_name,
+                            radio_enabled=not radio_disabled,
                             band=WirelessInterface._band_from_raw(
                                 vals.get(radio_name, {}).get("band", "")
                                 or vals.get(radio_name, {}).get("hwmode", "")

--- a/custom_components/openwrt/api/ubus/network.py
+++ b/custom_components/openwrt/api/ubus/network.py
@@ -71,12 +71,16 @@ class UbusNetworkMixin:
                                 continue
 
                             iface_config = iface.get("config", {})
+                            iface_disabled = WirelessInterface._uci_disabled(
+                                iface_config.get("disabled", False)
+                            )
                             wifi = WirelessInterface(
                                 name=iface_name,
                                 ssid=iface_config.get("ssid", ""),
                                 mode=iface_config.get("mode", ""),
                                 encryption=iface_config.get("encryption", ""),
                                 enabled=not radio_data.get("disabled", False),
+                                interface_enabled=not iface_disabled,
                                 up=not radio_data.get("disabled", False),
                                 radio=radio_name,
                                 radio_enabled=not radio_data.get("disabled", False),
@@ -134,6 +138,7 @@ class UbusNetworkMixin:
                             mode=sect_data.get("mode", ""),
                             encryption=sect_data.get("encryption", ""),
                             enabled=not (radio_disabled or iface_disabled),
+                            interface_enabled=not iface_disabled,
                             up=not (radio_disabled or iface_disabled),
                             radio=radio_name,
                             radio_enabled=not radio_disabled,

--- a/custom_components/openwrt/api/ubus/wireless.py
+++ b/custom_components/openwrt/api/ubus/wireless.py
@@ -107,6 +107,7 @@ class UbusWirelessMixin:
 
     async def set_wireless_enabled(self, interface: str, enabled: bool) -> bool:
         """Enable or disable a wireless radio via UCI."""
+        committed = False
         try:
             action = "0" if enabled else "1"  # disabled=0 means enabled
             await self._call(
@@ -119,11 +120,21 @@ class UbusWirelessMixin:
                 },
             )
             await self._call("uci", "commit", {"config": "wireless"})
+            committed = True
             await self._call("network.wireless", "notify")
             self._last_full_poll = 0
             return True
         except UbusError:
+            if not committed:
+                await self._revert_wireless_changes()
             return False
+
+    async def _revert_wireless_changes(self) -> None:
+        """Best-effort discard of an incomplete wireless UCI transaction."""
+        try:
+            await self._call("uci", "revert", {"config": "wireless"})
+        except UbusError as err:
+            _LOGGER.debug("Failed to revert incomplete wireless UCI changes: %s", err)
 
     async def set_wireless_network_enabled(
         self,
@@ -134,6 +145,7 @@ class UbusWirelessMixin:
         disable_radio: bool,
     ) -> bool:
         """Set an SSID and its radio in one UCI transaction."""
+        committed = False
         try:
             if enabled:
                 await self._call(
@@ -165,10 +177,13 @@ class UbusWirelessMixin:
                     },
                 )
             await self._call("uci", "commit", {"config": "wireless"})
+            committed = True
             await self._call("network.wireless", "notify")
             self._last_full_poll = 0
             return True
         except UbusError:
+            if not committed:
+                await self._revert_wireless_changes()
             return False
 
     async def get_wifi_credentials(self) -> list[WifiCredentials]:

--- a/custom_components/openwrt/api/ubus/wireless.py
+++ b/custom_components/openwrt/api/ubus/wireless.py
@@ -125,6 +125,52 @@ class UbusWirelessMixin:
         except UbusError:
             return False
 
+    async def set_wireless_network_enabled(
+        self,
+        interface: str,
+        radio: str,
+        enabled: bool,
+        *,
+        disable_radio: bool,
+    ) -> bool:
+        """Set an SSID and its radio in one UCI transaction."""
+        try:
+            if enabled:
+                await self._call(
+                    "uci",
+                    "set",
+                    {
+                        "config": "wireless",
+                        "section": radio,
+                        "values": {"disabled": "0"},
+                    },
+                )
+            await self._call(
+                "uci",
+                "set",
+                {
+                    "config": "wireless",
+                    "section": interface,
+                    "values": {"disabled": "0" if enabled else "1"},
+                },
+            )
+            if disable_radio:
+                await self._call(
+                    "uci",
+                    "set",
+                    {
+                        "config": "wireless",
+                        "section": radio,
+                        "values": {"disabled": "1"},
+                    },
+                )
+            await self._call("uci", "commit", {"config": "wireless"})
+            await self._call("network.wireless", "notify")
+            self._last_full_poll = 0
+            return True
+        except UbusError:
+            return False
+
     async def get_wifi_credentials(self) -> list[WifiCredentials]:
         """Get wifi credentials via UCI."""
         try:

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -1749,7 +1749,11 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
         )
 
         for connected in data.connected_devices:
-            if not connected.mac or not connected.connected or not connected.is_wireless:
+            if (
+                not connected.mac
+                or not connected.connected
+                or not connected.is_wireless
+            ):
                 continue
 
             mac = connected.mac.lower()
@@ -1909,9 +1913,7 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             manufacturer = device_info.release_distribution or ATTR_MANUFACTURER
             radio_device = device_registry.async_get_or_create(
                 config_entry_id=self.config_entry.entry_id,
-                identifiers={
-                    (DOMAIN, format_radio_device_id(self.router_id, radio))
-                },
+                identifiers={(DOMAIN, format_radio_device_id(self.router_id, radio))},
                 name=label,
                 manufacturer=manufacturer,
                 model="Wireless Radio",
@@ -1976,8 +1978,7 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 device_registry.async_update_device(
                     ssid_device.id,
                     name=label,
-                    manufacturer=device_info.release_distribution
-                    or ATTR_MANUFACTURER,
+                    manufacturer=device_info.release_distribution or ATTR_MANUFACTURER,
                     model="Wireless SSID",
                     via_device_id=radio_devices[radio].id,
                 )

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -101,6 +101,7 @@ from .helpers import (
     format_ap_name,
     format_radio_device_id,
     format_radio_name,
+    get_via_device,
     is_random_mac,
     normalize_band,
 )
@@ -1733,6 +1734,42 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 own_macs.add(wifi_iface.mac_address.lower())
         return own_macs
 
+    def _async_reparent_connected_devices(
+        self,
+        data: OpenWrtData,
+        device_registry: dr.DeviceRegistry,
+    ) -> None:
+        """Move existing wireless client devices below their current SSID."""
+        for connected in data.connected_devices:
+            if not connected.mac or not connected.connected or not connected.is_wireless:
+                continue
+
+            mac = connected.mac.lower()
+            client_device = device_registry.async_get_device(
+                identifiers={(DOMAIN, mac)},
+                connections={(dr.CONNECTION_NETWORK_MAC, mac)},
+            )
+            if client_device is None:
+                continue
+
+            parent_identifier = get_via_device(
+                self.hass,
+                self,
+                self.config_entry,
+                mac,
+            )
+            parent_device = device_registry.async_get_device(
+                identifiers={parent_identifier}
+            )
+            if (
+                parent_device is not None
+                and client_device.via_device_id != parent_device.id
+            ):
+                device_registry.async_update_device(
+                    client_device.id,
+                    via_device_id=parent_device.id,
+                )
+
     async def _async_update_device_registry(self, data: OpenWrtData) -> None:
         """Update the device registry with fresh device information."""
         if not data.device_info:
@@ -1885,6 +1922,10 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             # Use SSID and Band as stable identifier to group virtual interfaces
             stable_id = f"{wifi.ssid}_{band}"
             self.interface_to_stable_id[wifi.name] = stable_id
+            if wifi.section:
+                self.interface_to_stable_id[wifi.section] = stable_id
+            if wifi.ifname:
+                self.interface_to_stable_id[wifi.ifname] = stable_id
             ap_info[stable_id] = (label, wifi.radio)
 
         for stable_id, (label, radio) in ap_info.items():
@@ -1910,6 +1951,8 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                     model="Wireless SSID",
                     via_device_id=radio_devices[radio].id,
                 )
+
+        self._async_reparent_connected_devices(data, device_registry)
 
         # 3. Retroactively update manufacturer/model for already-registered tracked devices.
         # HA only writes manufacturer/model at first creation; subsequent coordinator polls

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -99,7 +99,9 @@ from .const import (
 from .helpers import (
     format_ap_device_id,
     format_ap_name,
+    format_radio_device_id,
     is_random_mac,
+    normalize_band,
 )
 from .helpers.mac_vendor import get_mac_vendor_info
 from .repairs import (
@@ -1825,7 +1827,27 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             configuration_url=f"http://{self.config_entry.data[CONF_HOST]}",
         )
 
-        # 2. Register/Update AP devices for wireless interfaces
+        # 2. Register physical radios and AP devices for wireless interfaces.
+        radio_info: dict[str, str] = {}
+        for wifi in data.wireless_interfaces:
+            if not wifi.radio:
+                continue
+            band = normalize_band(wifi.band or wifi.frequency or wifi.radio)
+            radio_info.setdefault(wifi.radio, band)
+
+        for radio, band in radio_info.items():
+            label = f"{radio} ({band})" if band != "unknown" else radio
+            device_registry.async_get_or_create(
+                config_entry_id=self.config_entry.entry_id,
+                identifiers={
+                    (DOMAIN, format_radio_device_id(self.router_id, radio))
+                },
+                name=f"Radio {label}",
+                manufacturer=device_info.release_distribution or ATTR_MANUFACTURER,
+                model="Wireless Radio",
+                via_device=(DOMAIN, self.router_id),
+            )
+
         # Ensure stable_id is based on SSID and Band to prevent duplicates
         # for mesh routers that spawn multiple virtual interfaces per radio.
         ap_info: dict[str, str] = {}
@@ -1839,8 +1861,6 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             # than the raw frequency in MHz. This groups all virtual interfaces on
             # the same radio+SSID combination under one stable AP device, even
             # when different channels are reported across updates.
-            from .helpers import normalize_band
-
             band = normalize_band(wifi.band or wifi.frequency or wifi.radio)
             label = format_ap_name(wifi.ssid, band)
 
@@ -1921,6 +1941,10 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
         for stable_id in ap_info.keys():
             active_identifiers.add(
                 (DOMAIN, format_ap_device_id(self.router_id, stable_id))
+            )
+        for radio in radio_info:
+            active_identifiers.add(
+                (DOMAIN, format_radio_device_id(self.router_id, radio))
             )
 
         _LOGGER.debug(

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -1922,10 +1922,6 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             # Use SSID and Band as stable identifier to group virtual interfaces
             stable_id = f"{wifi.ssid}_{band}"
             self.interface_to_stable_id[wifi.name] = stable_id
-            if wifi.section:
-                self.interface_to_stable_id[wifi.section] = stable_id
-            if wifi.ifname:
-                self.interface_to_stable_id[wifi.ifname] = stable_id
             ap_info[stable_id] = (label, wifi.radio)
 
         for stable_id, (label, radio) in ap_info.items():

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -1741,18 +1741,35 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
         device_registry: dr.DeviceRegistry,
     ) -> None:
         """Move existing wireless client devices below their current SSID."""
+        get_by_identifier = getattr(
+            device_registry, "async_get_device_by_identifier", None
+        )
+        get_by_connection = getattr(
+            device_registry, "async_get_device_by_connection", None
+        )
+
         for connected in data.connected_devices:
             if not connected.mac or not connected.connected or not connected.is_wireless:
                 continue
 
             mac = connected.mac.lower()
-            client_device = device_registry.async_get_device_by_identifier(
-                (DOMAIN, mac), self.config_entry.entry_id
-            )
-            if client_device is None:
-                client_device = device_registry.async_get_device_by_connection(
-                    (dr.CONNECTION_NETWORK_MAC, mac), self.config_entry.entry_id
+            if get_by_identifier is not None:
+                client_device = get_by_identifier(
+                    (DOMAIN, mac), self.config_entry.entry_id
                 )
+            else:
+                client_device = device_registry.async_get_device(
+                    identifiers={(DOMAIN, mac)}
+                )
+            if client_device is None:
+                if get_by_connection is not None:
+                    client_device = get_by_connection(
+                        (dr.CONNECTION_NETWORK_MAC, mac), self.config_entry.entry_id
+                    )
+                else:
+                    client_device = device_registry.async_get_device(
+                        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
+                    )
             if client_device is None:
                 continue
 
@@ -1762,9 +1779,14 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 self.config_entry,
                 mac,
             )
-            parent_device = device_registry.async_get_device_by_identifier(
-                parent_identifier, self.config_entry.entry_id
-            )
+            if get_by_identifier is not None:
+                parent_device = get_by_identifier(
+                    parent_identifier, self.config_entry.entry_id
+                )
+            else:
+                parent_device = device_registry.async_get_device(
+                    identifiers={parent_identifier}
+                )
             if (
                 parent_device is not None
                 and client_device.via_device_id != parent_device.id

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -99,6 +99,7 @@ from .const import (
 from .helpers import (
     format_ap_device_id,
     format_ap_name,
+    format_ap_stable_id,
     format_radio_device_id,
     format_radio_name,
     get_via_device,
@@ -1745,10 +1746,13 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 continue
 
             mac = connected.mac.lower()
-            client_device = device_registry.async_get_device(
-                identifiers={(DOMAIN, mac)},
-                connections={(dr.CONNECTION_NETWORK_MAC, mac)},
+            client_device = device_registry.async_get_device_by_identifier(
+                (DOMAIN, mac), self.config_entry.entry_id
             )
+            if client_device is None:
+                client_device = device_registry.async_get_device_by_connection(
+                    (dr.CONNECTION_NETWORK_MAC, mac), self.config_entry.entry_id
+                )
             if client_device is None:
                 continue
 
@@ -1758,8 +1762,8 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 self.config_entry,
                 mac,
             )
-            parent_device = device_registry.async_get_device(
-                identifiers={parent_identifier}
+            parent_device = device_registry.async_get_device_by_identifier(
+                parent_identifier, self.config_entry.entry_id
             )
             if (
                 parent_device is not None
@@ -1870,7 +1874,11 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
         for wifi in data.wireless_interfaces:
             if not wifi.radio:
                 continue
-            band = normalize_band(wifi.band or wifi.frequency or wifi.radio)
+            band = (
+                normalize_band(wifi.band or wifi.frequency)
+                if wifi.band or wifi.frequency
+                else ""
+            )
             radio_info.setdefault(wifi.radio, band)
 
         radio_devices: dict[str, dr.DeviceEntry] = {}
@@ -1916,11 +1924,15 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             # than the raw frequency in MHz. This groups all virtual interfaces on
             # the same radio+SSID combination under one stable AP device, even
             # when different channels are reported across updates.
-            band = normalize_band(wifi.band or wifi.frequency or wifi.radio)
+            band = (
+                normalize_band(wifi.band or wifi.frequency)
+                if wifi.band or wifi.frequency
+                else ""
+            )
             label = format_ap_name(wifi.ssid, band)
 
-            # Use SSID and Band as stable identifier to group virtual interfaces
-            stable_id = f"{wifi.ssid}_{band}"
+            # Group virtual interfaces only within the same physical radio.
+            stable_id = format_ap_stable_id(wifi.ssid, band, wifi.radio)
             self.interface_to_stable_id[wifi.name] = stable_id
             ap_info[stable_id] = (label, wifi.radio)
 

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -1838,16 +1838,31 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
 
         for radio, band in radio_info.items():
             label = format_radio_name(radio, band)
-            device_registry.async_get_or_create(
+            manufacturer = device_info.release_distribution or ATTR_MANUFACTURER
+            radio_device = device_registry.async_get_or_create(
                 config_entry_id=self.config_entry.entry_id,
                 identifiers={
                     (DOMAIN, format_radio_device_id(self.router_id, radio))
                 },
                 name=label,
-                manufacturer=device_info.release_distribution or ATTR_MANUFACTURER,
+                manufacturer=manufacturer,
                 model="Wireless Radio",
                 via_device=(DOMAIN, self.router_id),
             )
+            # async_get_or_create() preserves an existing device name. Explicitly
+            # migrate names created by earlier integration versions while leaving a
+            # user's name_by_user override untouched.
+            if (
+                radio_device.name != label
+                or radio_device.manufacturer != manufacturer
+                or radio_device.model != "Wireless Radio"
+            ):
+                device_registry.async_update_device(
+                    radio_device.id,
+                    name=label,
+                    manufacturer=manufacturer,
+                    model="Wireless Radio",
+                )
 
         # Ensure stable_id is based on SSID and Band to prevent duplicates
         # for mesh routers that spawn multiple virtual interfaces per radio.

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -1882,8 +1882,12 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
 
             # Use SSID and Band as stable identifier to group virtual interfaces
             stable_id = f"{wifi.ssid}_{band}"
-            ap_info[stable_id] = label
             self.interface_to_stable_id[wifi.name] = stable_id
+            # Interfaces with a known physical radio are represented by that radio
+            # device. Keep a legacy AP device only when OpenWrt cannot identify the
+            # owning radio.
+            if not wifi.radio:
+                ap_info[stable_id] = label
 
         for stable_id, label in ap_info.items():
             device_registry.async_get_or_create(

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -100,6 +100,7 @@ from .helpers import (
     format_ap_device_id,
     format_ap_name,
     format_radio_device_id,
+    format_radio_name,
     is_random_mac,
     normalize_band,
 )
@@ -1836,13 +1837,13 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             radio_info.setdefault(wifi.radio, band)
 
         for radio, band in radio_info.items():
-            label = f"{radio} ({band})" if band != "unknown" else radio
+            label = format_radio_name(radio, band)
             device_registry.async_get_or_create(
                 config_entry_id=self.config_entry.entry_id,
                 identifiers={
                     (DOMAIN, format_radio_device_id(self.router_id, radio))
                 },
-                name=f"Radio {label}",
+                name=label,
                 manufacturer=device_info.release_distribution or ATTR_MANUFACTURER,
                 model="Wireless Radio",
                 via_device=(DOMAIN, self.router_id),

--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -1836,6 +1836,7 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             band = normalize_band(wifi.band or wifi.frequency or wifi.radio)
             radio_info.setdefault(wifi.radio, band)
 
+        radio_devices: dict[str, dr.DeviceEntry] = {}
         for radio, band in radio_info.items():
             label = format_radio_name(radio, band)
             manufacturer = device_info.release_distribution or ATTR_MANUFACTURER
@@ -1849,6 +1850,7 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 model="Wireless Radio",
                 via_device=(DOMAIN, self.router_id),
             )
+            radio_devices[radio] = radio_device
             # async_get_or_create() preserves an existing device name. Explicitly
             # migrate names created by earlier integration versions while leaving a
             # user's name_by_user override untouched.
@@ -1866,7 +1868,7 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
 
         # Ensure stable_id is based on SSID and Band to prevent duplicates
         # for mesh routers that spawn multiple virtual interfaces per radio.
-        ap_info: dict[str, str] = {}
+        ap_info: dict[str, tuple[str, str]] = {}
 
         for wifi in data.wireless_interfaces:
             # Skip interfaces without name or SSID
@@ -1883,21 +1885,31 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             # Use SSID and Band as stable identifier to group virtual interfaces
             stable_id = f"{wifi.ssid}_{band}"
             self.interface_to_stable_id[wifi.name] = stable_id
-            # Interfaces with a known physical radio are represented by that radio
-            # device. Keep a legacy AP device only when OpenWrt cannot identify the
-            # owning radio.
-            if not wifi.radio:
-                ap_info[stable_id] = label
+            ap_info[stable_id] = (label, wifi.radio)
 
-        for stable_id, label in ap_info.items():
-            device_registry.async_get_or_create(
+        for stable_id, (label, radio) in ap_info.items():
+            ssid_device = device_registry.async_get_or_create(
                 config_entry_id=self.config_entry.entry_id,
                 identifiers={(DOMAIN, format_ap_device_id(self.router_id, stable_id))},
                 name=label,
                 manufacturer=device_info.release_distribution or ATTR_MANUFACTURER,
-                model="Access Point",
-                via_device=(DOMAIN, self.router_id),
+                model="Wireless SSID",
+                via_device=(
+                    DOMAIN,
+                    format_radio_device_id(self.router_id, radio),
+                )
+                if radio
+                else (DOMAIN, self.router_id),
             )
+            if radio and radio in radio_devices:
+                device_registry.async_update_device(
+                    ssid_device.id,
+                    name=label,
+                    manufacturer=device_info.release_distribution
+                    or ATTR_MANUFACTURER,
+                    model="Wireless SSID",
+                    via_device_id=radio_devices[radio].id,
+                )
 
         # 3. Retroactively update manufacturer/model for already-registered tracked devices.
         # HA only writes manufacturer/model at first creation; subsequent coordinator polls

--- a/custom_components/openwrt/helpers/__init__.py
+++ b/custom_components/openwrt/helpers/__init__.py
@@ -53,6 +53,12 @@ def format_radio_device_id(
     return f"{router_id}_radio_{radio}"
 
 
+def format_radio_name(radio: str, band: str | None) -> str:
+    """Return a concise radio display name with a stable fallback."""
+    normalized_band = normalize_band(band) if band else "unknown"
+    return normalized_band if normalized_band != "unknown" else radio
+
+
 def normalize_band(band: str | None) -> str:
     """Normalize raw frequency or band strings to a standard format.
 

--- a/custom_components/openwrt/helpers/__init__.py
+++ b/custom_components/openwrt/helpers/__init__.py
@@ -108,18 +108,12 @@ def normalize_band(band: str | None) -> str:
 
 
 def format_ap_name(ssid: str, band: str = "") -> str:
-    """Format the display name for an Access Point device.
+    """Format the display name for an SSID device.
 
     Examples:
-        format_ap_name("SmartLife", "2.4 GHz") -> "AP SmartLife (2.4 GHz)"
-        format_ap_name("SmartLife", "2412")     -> "AP SmartLife (2.4 GHz)"
+        format_ap_name("SmartLife", "2.4 GHz") -> "SSID SmartLife"
     """
-    label = ssid
-    norm_band = normalize_band(band) if band else ""
-
-    if norm_band and norm_band != "unknown":
-        return f"AP {label} ({norm_band})"
-    return f"AP {label}"
+    return f"SSID {ssid}"
 
 
 def is_random_mac(mac: str) -> bool:
@@ -171,8 +165,8 @@ def get_via_device(
 ) -> tuple[str, str]:
     """Resolve the via_device for a connected device.
 
-    Returns a tuple (DOMAIN, identifier). Falls back to the router if
-    the AP device is not found in the registry or if the device is wired.
+    Returns a tuple (DOMAIN, identifier). Wireless clients are attached to
+    their physical radio; wired or ambiguous clients fall back to the router.
     """
     from homeassistant.helpers import device_registry as dr
 
@@ -189,13 +183,27 @@ def get_via_device(
                 and device.is_wireless
                 and device.interface
             ):
+                dev_reg = dr.async_get(hass)
+                wifi = next(
+                    (
+                        item
+                        for item in coordinator.data.wireless_interfaces
+                        if device.interface
+                        in {item.name, item.section, item.ifname}
+                    ),
+                    None,
+                )
                 stable_id = coordinator.interface_to_stable_id.get(device.interface)
                 if stable_id:
                     ap_id = format_ap_device_id(router_id, stable_id)
-                    # Verify the AP device exists to avoid "non existing via_device" warnings
-                    dev_reg = dr.async_get(hass)
                     if dev_reg.async_get_device(identifiers={(DOMAIN, ap_id)}):
                         via_device = (DOMAIN, ap_id)
+                elif wifi and wifi.radio:
+                    radio_id = format_radio_device_id(router_id, wifi.radio)
+                    if dev_reg.async_get_device(
+                        identifiers={(DOMAIN, radio_id)}
+                    ):
+                        via_device = (DOMAIN, radio_id)
                 break
 
         # If not local wireless, check Batman-adv mesh for remote nodes

--- a/custom_components/openwrt/helpers/__init__.py
+++ b/custom_components/openwrt/helpers/__init__.py
@@ -40,6 +40,19 @@ def format_ap_device_id(entry_or_router_id: ConfigEntry | str, iface_name: str) 
     return format_ap_identifier(entry_or_router_id, iface_name)
 
 
+def format_radio_device_id(
+    entry_or_router_id: ConfigEntry | str,
+    radio: str,
+) -> str:
+    """Return the canonical device registry identifier for a physical radio."""
+    router_id = (
+        entry_or_router_id
+        if isinstance(entry_or_router_id, str)
+        else _router_id(entry_or_router_id)
+    )
+    return f"{router_id}_radio_{radio}"
+
+
 def normalize_band(band: str | None) -> str:
     """Normalize raw frequency or band strings to a standard format.
 

--- a/custom_components/openwrt/helpers/__init__.py
+++ b/custom_components/openwrt/helpers/__init__.py
@@ -210,8 +210,7 @@ def get_via_device(
                     (
                         item
                         for item in coordinator.data.wireless_interfaces
-                        if device.interface
-                        in {item.name, item.section, item.ifname}
+                        if device.interface in {item.name, item.section, item.ifname}
                     ),
                     None,
                 )
@@ -224,9 +223,7 @@ def get_via_device(
                         via_device = (DOMAIN, ap_id)
                 elif wifi and wifi.radio:
                     radio_id = format_radio_device_id(router_id, wifi.radio)
-                    if dev_reg.async_get_device(
-                        identifiers={(DOMAIN, radio_id)}
-                    ):
+                    if dev_reg.async_get_device(identifiers={(DOMAIN, radio_id)}):
                         via_device = (DOMAIN, radio_id)
                 break
 

--- a/custom_components/openwrt/helpers/__init__.py
+++ b/custom_components/openwrt/helpers/__init__.py
@@ -53,6 +53,11 @@ def format_radio_device_id(
     return f"{router_id}_radio_{radio}"
 
 
+def format_ap_stable_id(ssid: str, band: str, radio: str = "") -> str:
+    """Return an AP identifier distinct across physical radios."""
+    return f"{radio}_{ssid}_{band}" if radio else f"{ssid}_{band}"
+
+
 def format_radio_name(radio: str, band: str | None) -> str:
     """Return a concise radio display name with a stable fallback."""
     normalized_band = normalize_band(band) if band else "unknown"

--- a/custom_components/openwrt/helpers/__init__.py
+++ b/custom_components/openwrt/helpers/__init__.py
@@ -73,6 +73,23 @@ def normalize_band(band: str | None) -> str:
 
     freq_str = str(band).lower().strip()
 
+    uci_band_aliases = {
+        "2g": "2.4 GHz",
+        "2ghz": "2.4 GHz",
+        "2 ghz": "2.4 GHz",
+        "2g ghz": "2.4 GHz",
+        "5g": "5 GHz",
+        "5ghz": "5 GHz",
+        "5 ghz": "5 GHz",
+        "5g ghz": "5 GHz",
+        "6g": "6 GHz",
+        "6ghz": "6 GHz",
+        "6 ghz": "6 GHz",
+        "6g ghz": "6 GHz",
+    }
+    if freq_str in uci_band_aliases:
+        return uci_band_aliases[freq_str]
+
     # Handle numeric MHz/GHz strings
     try:
         # Remove units if present for numeric check

--- a/custom_components/openwrt/helpers/__init__.py
+++ b/custom_components/openwrt/helpers/__init__.py
@@ -194,6 +194,8 @@ def get_via_device(
                     None,
                 )
                 stable_id = coordinator.interface_to_stable_id.get(device.interface)
+                if not stable_id and wifi:
+                    stable_id = coordinator.interface_to_stable_id.get(wifi.name)
                 if stable_id:
                     ap_id = format_ap_device_id(router_id, stable_id)
                     if dev_reg.async_get_device(identifiers={(DOMAIN, ap_id)}):

--- a/custom_components/openwrt/number.py
+++ b/custom_components/openwrt/number.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN
 from .coordinator import OpenWrtDataCoordinator
+from .helpers import format_radio_device_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -144,7 +145,7 @@ class OpenWrtTxPowerNumber(CoordinatorEntity[OpenWrtDataCoordinator], NumberEnti
         self._attr_name = f"{label} TX Power"
         self._attr_unique_id = f"{entry.entry_id}_txpower_{radio}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{entry.unique_id}_radio_{radio}")},
+            identifiers={(DOMAIN, format_radio_device_id(entry, radio))},
             name=f"Radio {label}",
             manufacturer="OpenWrt",
             model="Wireless Radio",

--- a/custom_components/openwrt/number.py
+++ b/custom_components/openwrt/number.py
@@ -141,11 +141,13 @@ class OpenWrtTxPowerNumber(CoordinatorEntity[OpenWrtDataCoordinator], NumberEnti
         self._attr_name = "Transmit power"
         self._attr_unique_id = f"{entry.entry_id}_txpower_{radio}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, format_radio_device_id(entry, radio))},
+            identifiers={
+                (DOMAIN, format_radio_device_id(coordinator.router_id, radio))
+            },
             name=label,
             manufacturer="OpenWrt",
             model="Wireless Radio",
-            via_device=(DOMAIN, cast(str, entry.unique_id)),
+            via_device=(DOMAIN, coordinator.router_id),
         )
 
     @property

--- a/custom_components/openwrt/number.py
+++ b/custom_components/openwrt/number.py
@@ -48,7 +48,7 @@ async def async_setup_entry(
         # TX Power is configured on the physical radio, not on an SSID interface.
         if perms.write_wireless:
             for wifi in coordinator.data.wireless_interfaces:
-                if wifi.radio and wifi.txpower >= 0:
+                if wifi.radio and wifi.txpower > 0:
                     key = f"txpower_{wifi.radio}"
                     if key not in tracked_keys:
                         tracked_keys.add(key)
@@ -123,7 +123,7 @@ class OpenWrtTxPowerNumber(CoordinatorEntity[OpenWrtDataCoordinator], NumberEnti
 
     _attr_has_entity_name = True
     _attr_mode = NumberMode.SLIDER
-    _attr_native_min_value = 0
+    _attr_native_min_value = 1
     _attr_native_max_value = 30
     _attr_native_step = 1
     _attr_native_unit_of_measurement = "dBm"
@@ -142,7 +142,7 @@ class OpenWrtTxPowerNumber(CoordinatorEntity[OpenWrtDataCoordinator], NumberEnti
         self._radio = radio
         self._entry = entry
         label = format_radio_name(radio, band)
-        self._attr_name = "TX Power"
+        self._attr_name = "Transmit power"
         self._attr_unique_id = f"{entry.entry_id}_txpower_{radio}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, format_radio_device_id(entry, radio))},
@@ -169,7 +169,7 @@ class OpenWrtTxPowerNumber(CoordinatorEntity[OpenWrtDataCoordinator], NumberEnti
         """Return the current TX power."""
         if self.coordinator.data:
             for wifi in self.coordinator.data.wireless_interfaces:
-                if wifi.radio == self._radio and wifi.txpower >= 0:
+                if wifi.radio == self._radio and wifi.txpower > 0:
                     return wifi.txpower
         return None
 

--- a/custom_components/openwrt/number.py
+++ b/custom_components/openwrt/number.py
@@ -13,6 +13,7 @@ from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -95,27 +96,22 @@ async def async_setup_entry(
     entry.async_on_unload(coordinator.async_add_listener(_async_add_new_entities))
     _async_add_new_entities()
 
-    def _async_cleanup_entities() -> None:
-        """Remove orphaned number entities when radios/interfaces vanish."""
-        from homeassistant.helpers import entity_registry as er
-
-        ent_reg = er.async_get(hass)
-        entries = er.async_entries_for_config_entry(ent_reg, entry.entry_id)
-
-        for ent in entries:
-            if ent.domain != "number":
-                continue
-
-            unique_id = ent.unique_id
-            if "_txpower_" in unique_id and coordinator.data:
-                radio = unique_id.split("_txpower_")[-1]
-                if not any(
-                    w.radio == radio
-                    for w in coordinator.data.wireless_interfaces
-                ):
-                    ent_reg.async_remove(ent.entity_id)
-
-    hass.add_job(_async_cleanup_entities)
+    # Remove legacy or invalid TX-power sliders. A zero reading means OpenWrt did
+    # not provide a usable value; keeping the old registry entry would display a
+    # fabricated 0 dBm control after upgrades.
+    valid_txpower_ids = {
+        f"{entry.entry_id}_txpower_{wifi.radio}"
+        for wifi in coordinator.data.wireless_interfaces
+        if wifi.radio and wifi.txpower > 0
+    }
+    entity_registry = er.async_get(hass)
+    for entity in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
+        if (
+            entity.domain == "number"
+            and "_txpower_" in entity.unique_id
+            and entity.unique_id not in valid_txpower_ids
+        ):
+            entity_registry.async_remove(entity.entity_id)
 
 
 class OpenWrtTxPowerNumber(CoordinatorEntity[OpenWrtDataCoordinator], NumberEntity):

--- a/custom_components/openwrt/number.py
+++ b/custom_components/openwrt/number.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN
 from .coordinator import OpenWrtDataCoordinator
-from .helpers import format_radio_device_id
+from .helpers import format_radio_device_id, format_radio_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -141,12 +141,12 @@ class OpenWrtTxPowerNumber(CoordinatorEntity[OpenWrtDataCoordinator], NumberEnti
         super().__init__(coordinator)
         self._radio = radio
         self._entry = entry
-        label = f"{radio} ({band})" if band else radio
-        self._attr_name = f"{label} TX Power"
+        label = format_radio_name(radio, band)
+        self._attr_name = "TX Power"
         self._attr_unique_id = f"{entry.entry_id}_txpower_{radio}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, format_radio_device_id(entry, radio))},
-            name=f"Radio {label}",
+            name=label,
             manufacturer="OpenWrt",
             model="Wireless Radio",
             via_device=(DOMAIN, cast(str, entry.unique_id)),

--- a/custom_components/openwrt/number.py
+++ b/custom_components/openwrt/number.py
@@ -19,7 +19,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN
 from .coordinator import OpenWrtDataCoordinator
-from .helpers import _router_id, format_ap_device_id, format_ap_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,21 +44,19 @@ async def async_setup_entry(
         perms = coordinator.data.permissions
         pkgs = coordinator.data.packages
 
-        # TX Power per wireless interface
+        # TX Power is configured on the physical radio, not on an SSID interface.
         if perms.write_wireless:
             for wifi in coordinator.data.wireless_interfaces:
-                if wifi.name and wifi.txpower >= 0:
-                    key = f"txpower_{wifi.section or wifi.name}"
+                if wifi.radio and wifi.txpower >= 0:
+                    key = f"txpower_{wifi.radio}"
                     if key not in tracked_keys:
                         tracked_keys.add(key)
                         new_entities.append(
                             OpenWrtTxPowerNumber(
                                 coordinator,
                                 entry,
-                                wifi.name,
-                                wifi.ssid,
-                                wifi.frequency,
-                                wifi.section,
+                                wifi.radio,
+                                wifi.band,
                             ),
                         )
 
@@ -110,9 +107,9 @@ async def async_setup_entry(
 
             unique_id = ent.unique_id
             if "_txpower_" in unique_id and coordinator.data:
-                iface_name = unique_id.split("_txpower_")[-1]
+                radio = unique_id.split("_txpower_")[-1]
                 if not any(
-                    w.name == iface_name or w.section == iface_name
+                    w.radio == radio
                     for w in coordinator.data.wireless_interfaces
                 ):
                     ent_reg.async_remove(ent.entity_id)
@@ -130,50 +127,28 @@ class OpenWrtTxPowerNumber(CoordinatorEntity[OpenWrtDataCoordinator], NumberEnti
     _attr_native_step = 1
     _attr_native_unit_of_measurement = "dBm"
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_entity_registry_enabled_default = False
     _attr_translation_key = "wifi_txpower_control"
 
     def __init__(
         self,
         coordinator: OpenWrtDataCoordinator,
         entry: ConfigEntry,
-        iface_name: str,
-        ssid: str,
-        frequency: str = "",
-        section_id: str | None = None,
+        radio: str,
+        band: str,
     ) -> None:
         """Initialize the TX Power number entity."""
         super().__init__(coordinator)
-        self._iface_name = iface_name
-        self._section_id = section_id
+        self._radio = radio
         self._entry = entry
-        self._attr_unique_id = f"{entry.entry_id}_txpower_{section_id or iface_name}"
-
-        stable_id = coordinator.interface_to_stable_id.get(
-            iface_name, section_id if section_id else iface_name
-        )
-        name_label = format_ap_name(ssid or iface_name, frequency)
-        if (
-            sum(
-                1
-                for sid in coordinator.interface_to_stable_id.values()
-                if sid == stable_id
-            )
-            > 1
-        ):
-            name_label = f"{name_label} [{iface_name}]"
-            self._attr_name = f"TX Power [{iface_name}]"
-        else:
-            self._attr_name = "TX Power"
-
+        label = f"{radio} ({band})" if band else radio
+        self._attr_name = f"{label} TX Power"
+        self._attr_unique_id = f"{entry.entry_id}_txpower_{radio}"
         self._attr_device_info = DeviceInfo(
-            identifiers={
-                (DOMAIN, format_ap_device_id(coordinator.router_id, stable_id))
-            },
-            name=name_label,
+            identifiers={(DOMAIN, f"{entry.unique_id}_radio_{radio}")},
+            name=f"Radio {label}",
             manufacturer="OpenWrt",
-            model="Access Point",
-            via_device=(DOMAIN, _router_id(entry)),
+            model="Wireless Radio",
+            via_device=(DOMAIN, cast(str, entry.unique_id)),
         )
 
     @property
@@ -181,9 +156,7 @@ class OpenWrtTxPowerNumber(CoordinatorEntity[OpenWrtDataCoordinator], NumberEnti
         """Return the maximum supported TX power limit."""
         if self.coordinator.data:
             for wifi in self.coordinator.data.wireless_interfaces:
-                if wifi.name == self._iface_name or (
-                    self._section_id and wifi.section == self._section_id
-                ):
+                if wifi.radio == self._radio:
                     if wifi.txpower_offset and wifi.txpower_offset > 0:
                         return float(wifi.txpower_offset)
                     if wifi.txpower > 30:
@@ -195,9 +168,7 @@ class OpenWrtTxPowerNumber(CoordinatorEntity[OpenWrtDataCoordinator], NumberEnti
         """Return the current TX power."""
         if self.coordinator.data:
             for wifi in self.coordinator.data.wireless_interfaces:
-                if wifi.name == self._iface_name or (
-                    self._section_id and wifi.section == self._section_id
-                ):
+                if wifi.radio == self._radio and wifi.txpower >= 0:
                     return wifi.txpower
         return None
 
@@ -206,29 +177,18 @@ class OpenWrtTxPowerNumber(CoordinatorEntity[OpenWrtDataCoordinator], NumberEnti
         client = self.hass.data[DOMAIN][self._entry.entry_id][DATA_CLIENT]
         txpower = int(value)
 
-        # Find the radio for this interface
-        radio = None
-        if self.coordinator.data:
-            for wifi in self.coordinator.data.wireless_interfaces:
-                if wifi.name == self._iface_name or (
-                    self._section_id and wifi.section == self._section_id
-                ):
-                    radio = wifi.radio
-                    break
-
-        if radio:
-            try:
-                await client.execute_command(
-                    f"uci set wireless.{radio}.txpower='{txpower}' && "
-                    f"uci commit wireless && wifi reload",
-                )
-            except Exception as err:
-                _LOGGER.exception(
-                    "Failed to set TX power for %s: %s",
-                    self._iface_name,
-                    err,
-                )
-                raise
+        try:
+            await client.execute_command(
+                f"uci set wireless.{self._radio}.txpower='{txpower}' && "
+                f"uci commit wireless && wifi reload",
+            )
+        except Exception as err:
+            _LOGGER.exception(
+                "Failed to set TX power for %s: %s",
+                self._radio,
+                err,
+            )
+            raise
 
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -164,26 +164,6 @@ class OpenWrtWifiSensorEntity(OpenWrtSensorEntity):
         # Ensure sensors are grouped under the correct AP device
         stable_id = coordinator.interface_to_stable_id.get(iface_name, iface_name)
 
-        # If multiple virtual interfaces map to the same AP device (e.g. mesh nodes),
-        # append the interface name to disambiguate the sensor entities.
-        if (
-            sum(
-                1
-                for sid in coordinator.interface_to_stable_id.values()
-                if sid == stable_id
-            )
-            > 1
-        ):
-            name_label = f"{name_label} [{iface_name}]"
-            # We also need to update the description name so the entity name reflects this.
-            # Use getattr to avoid AttributeError on HA versions where _attr_name has no
-            # class-level default until it is explicitly set.
-            existing_name = getattr(self, "_attr_name", None)
-            if existing_name:
-                self._attr_name = f"{existing_name} [{iface_name}]"
-            elif description.name:
-                self._attr_name = f"{description.name} [{iface_name}]"
-
         wifi = next(
             (
                 item

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -61,7 +61,6 @@ from .helpers import (
     format_ap_device_id,
     format_ap_name,
     format_radio_device_id,
-    format_radio_name,
     get_via_device,
     is_random_mac,
     normalize_band,
@@ -193,30 +192,21 @@ class OpenWrtWifiSensorEntity(OpenWrtSensorEntity):
             ),
             None,
         )
+        via_device = (DOMAIN, coordinator.router_id)
         if wifi and wifi.radio:
-            band = normalize_band(wifi.band or frequency or wifi.frequency)
-            self._attr_device_info = DeviceInfo(
-                identifiers={
-                    (
-                        DOMAIN,
-                        format_radio_device_id(coordinator.router_id, wifi.radio),
-                    )
-                },
-                name=format_radio_name(wifi.radio, band),
-                manufacturer="OpenWrt",
-                model="Wireless Radio",
-                via_device=(DOMAIN, coordinator.router_id),
+            via_device = (
+                DOMAIN,
+                format_radio_device_id(coordinator.router_id, wifi.radio),
             )
-        else:
-            self._attr_device_info = DeviceInfo(
-                identifiers={
-                    (DOMAIN, format_ap_device_id(coordinator.router_id, stable_id))
-                },
-                name=name_label,
-                manufacturer="OpenWrt",
-                model="Access Point",
-                via_device=(DOMAIN, coordinator.router_id),
-            )
+        self._attr_device_info = DeviceInfo(
+            identifiers={
+                (DOMAIN, format_ap_device_id(coordinator.router_id, stable_id))
+            },
+            name=name_label,
+            manufacturer="OpenWrt",
+            model="Wireless SSID",
+            via_device=via_device,
+        )
         self._attr_translation_placeholders = {"iface": iface_name}
 
 

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -63,7 +63,6 @@ from .helpers import (
     format_radio_device_id,
     get_via_device,
     is_random_mac,
-    normalize_band,
     resolve_client_name,
 )
 

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -60,8 +60,11 @@ from .coordinator import OpenWrtDataCoordinator
 from .helpers import (
     format_ap_device_id,
     format_ap_name,
+    format_radio_device_id,
+    format_radio_name,
     get_via_device,
     is_random_mac,
+    normalize_band,
     resolve_client_name,
 )
 
@@ -182,15 +185,38 @@ class OpenWrtWifiSensorEntity(OpenWrtSensorEntity):
             elif description.name:
                 self._attr_name = f"{description.name} [{iface_name}]"
 
-        self._attr_device_info = DeviceInfo(
-            identifiers={
-                (DOMAIN, format_ap_device_id(coordinator.router_id, stable_id))
-            },
-            name=name_label,
-            manufacturer="OpenWrt",
-            model="Access Point",
-            via_device=(DOMAIN, coordinator.router_id),
+        wifi = next(
+            (
+                item
+                for item in coordinator.data.wireless_interfaces
+                if item.name == iface_name
+            ),
+            None,
         )
+        if wifi and wifi.radio:
+            band = normalize_band(wifi.band or frequency or wifi.frequency)
+            self._attr_device_info = DeviceInfo(
+                identifiers={
+                    (
+                        DOMAIN,
+                        format_radio_device_id(coordinator.router_id, wifi.radio),
+                    )
+                },
+                name=format_radio_name(wifi.radio, band),
+                manufacturer="OpenWrt",
+                model="Wireless Radio",
+                via_device=(DOMAIN, coordinator.router_id),
+            )
+        else:
+            self._attr_device_info = DeviceInfo(
+                identifiers={
+                    (DOMAIN, format_ap_device_id(coordinator.router_id, stable_id))
+                },
+                name=name_label,
+                manufacturer="OpenWrt",
+                model="Access Point",
+                via_device=(DOMAIN, coordinator.router_id),
+            )
         self._attr_translation_placeholders = {"iface": iface_name}
 
 

--- a/custom_components/openwrt/switch.py
+++ b/custom_components/openwrt/switch.py
@@ -156,6 +156,14 @@ async def async_setup_entry(
                     ent_reg.async_remove(ent.entity_id)
                     continue
 
+            if "_radio_" in unique_id and coordinator.data:
+                radio = unique_id.split("_radio_")[-1]
+                if not any(
+                    wifi.radio == radio for wifi in coordinator.data.wireless_interfaces
+                ):
+                    ent_reg.async_remove(ent.entity_id)
+                    continue
+
     hass.add_job(_async_cleanup_entities)
 
 
@@ -922,6 +930,7 @@ class OpenWrtWirelessSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEnt
                             wifi.radio_enabled = True
                         elif disable_radio:
                             wifi.radio_enabled = False
+                        wifi.enabled = wifi.radio_enabled and wifi.interface_enabled
             self.async_write_ha_state()
         except HomeAssistantError:
             raise

--- a/custom_components/openwrt/switch.py
+++ b/custom_components/openwrt/switch.py
@@ -850,16 +850,6 @@ class OpenWrtWirelessSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEnt
         )
 
         name_label = format_ap_name(ssid or iface_name, frequency)
-        if (
-            sum(
-                1
-                for sid in coordinator.interface_to_stable_id.values()
-                if sid == stable_id
-            )
-            > 1
-        ):
-            name_label = f"{name_label} [{iface_name}]"
-            self._attr_name = f"SSID {ssid or iface_name} [{iface_name}]"
 
         via_device = (DOMAIN, _router_id(entry))
         if radio:

--- a/custom_components/openwrt/switch.py
+++ b/custom_components/openwrt/switch.py
@@ -35,7 +35,13 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import OpenWrtDataCoordinator
-from .helpers import _router_id, format_ap_device_id, format_ap_name, normalize_band
+from .helpers import (
+    _router_id,
+    format_ap_device_id,
+    format_ap_name,
+    format_radio_device_id,
+    normalize_band,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -754,7 +760,7 @@ class OpenWrtRadioSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEntity
         self._attr_name = f"Radio {label}"
         self._attr_unique_id = f"{entry.entry_id}_radio_{radio}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{entry.unique_id}_radio_{radio}")},
+            identifiers={(DOMAIN, format_radio_device_id(entry, radio))},
             name=f"Radio {label}",
             manufacturer="OpenWrt",
             model="Wireless Radio",
@@ -857,7 +863,7 @@ class OpenWrtWirelessSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEnt
         if radio:
             radio_label = f"{radio} ({band})" if band else radio
             self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, f"{entry.unique_id}_radio_{radio}")},
+                identifiers={(DOMAIN, format_radio_device_id(entry, radio))},
                 name=f"Radio {radio_label}",
                 manufacturer="OpenWrt",
                 model="Wireless Radio",

--- a/custom_components/openwrt/switch.py
+++ b/custom_components/openwrt/switch.py
@@ -301,7 +301,7 @@ def _add_wireless_switches(
                         client,
                         wifi.name,
                         wifi.ssid,
-                        wifi.frequency,
+                        wifi.frequency or wifi.band,
                         wifi.section,
                         wifi.radio,
                     ),
@@ -854,15 +854,25 @@ class OpenWrtWirelessSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEnt
             # Since this entity's name defaults to None (using device name), we need to set it explicitly
             self._attr_name = f"Radio [{iface_name}]"
 
-        self._attr_device_info = DeviceInfo(
-            identifiers={
-                (DOMAIN, format_ap_device_id(coordinator.router_id, stable_id))
-            },
-            name=name_label,
-            manufacturer="OpenWrt",
-            model="Access Point",
-            via_device=(DOMAIN, _router_id(entry)),
-        )
+        if radio:
+            radio_label = f"{radio} ({band})" if band else radio
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, f"{entry.unique_id}_radio_{radio}")},
+                name=f"Radio {radio_label}",
+                manufacturer="OpenWrt",
+                model="Wireless Radio",
+                via_device=(DOMAIN, _router_id(entry)),
+            )
+        else:
+            self._attr_device_info = DeviceInfo(
+                identifiers={
+                    (DOMAIN, format_ap_device_id(coordinator.router_id, stable_id))
+                },
+                name=name_label,
+                manufacturer="OpenWrt",
+                model="Access Point",
+                via_device=(DOMAIN, _router_id(entry)),
+            )
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/openwrt/switch.py
+++ b/custom_components/openwrt/switch.py
@@ -758,7 +758,7 @@ class OpenWrtRadioSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEntity
         self._client = client
         self._radio = radio
         label = format_radio_name(radio, band)
-        self._attr_name = "Radio"
+        self._attr_name = "Physical radio"
         self._attr_unique_id = f"{entry.entry_id}_radio_{radio}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, format_radio_device_id(entry, radio))},
@@ -843,6 +843,7 @@ class OpenWrtWirelessSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEnt
             "ssid": ssid or iface_name,
             "band": band,
         }
+        self._attr_name = f"SSID {ssid or iface_name}"
         # Use section ID as stable identifier if available
         stable_id = coordinator.interface_to_stable_id.get(
             iface_name, section_id if section_id else iface_name
@@ -858,8 +859,7 @@ class OpenWrtWirelessSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEnt
             > 1
         ):
             name_label = f"{name_label} [{iface_name}]"
-            # Since this entity's name defaults to None (using device name), we need to set it explicitly
-            self._attr_name = f"Radio [{iface_name}]"
+            self._attr_name = f"SSID {ssid or iface_name} [{iface_name}]"
 
         if radio:
             radio_label = format_radio_name(radio, band)

--- a/custom_components/openwrt/switch.py
+++ b/custom_components/openwrt/switch.py
@@ -861,25 +861,18 @@ class OpenWrtWirelessSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEnt
             name_label = f"{name_label} [{iface_name}]"
             self._attr_name = f"SSID {ssid or iface_name} [{iface_name}]"
 
+        via_device = (DOMAIN, _router_id(entry))
         if radio:
-            radio_label = format_radio_name(radio, band)
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, format_radio_device_id(entry, radio))},
-                name=radio_label,
-                manufacturer="OpenWrt",
-                model="Wireless Radio",
-                via_device=(DOMAIN, _router_id(entry)),
-            )
-        else:
-            self._attr_device_info = DeviceInfo(
-                identifiers={
-                    (DOMAIN, format_ap_device_id(coordinator.router_id, stable_id))
-                },
-                name=name_label,
-                manufacturer="OpenWrt",
-                model="Access Point",
-                via_device=(DOMAIN, _router_id(entry)),
-            )
+            via_device = (DOMAIN, format_radio_device_id(entry, radio))
+        self._attr_device_info = DeviceInfo(
+            identifiers={
+                (DOMAIN, format_ap_device_id(coordinator.router_id, stable_id))
+            },
+            name=name_label,
+            manufacturer="OpenWrt",
+            model="Wireless SSID",
+            via_device=via_device,
+        )
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/openwrt/switch.py
+++ b/custom_components/openwrt/switch.py
@@ -789,6 +789,7 @@ class OpenWrtRadioSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEntity
                 for wifi in self.coordinator.data.wireless_interfaces:
                     if wifi.radio == self._radio:
                         wifi.radio_enabled = enabled
+                        wifi.enabled = enabled and wifi.interface_enabled
             self.async_write_ha_state()
         except HomeAssistantError:
             raise

--- a/custom_components/openwrt/switch.py
+++ b/custom_components/openwrt/switch.py
@@ -276,6 +276,20 @@ def _add_wireless_switches(
         tracked_keys.add("wps")
         entities.append(OpenWrtWpsSwitch(coordinator, entry, client))
     for wifi in coordinator.data.wireless_interfaces:
+        if wifi.radio:
+            key = f"radio_{wifi.radio}"
+            if key not in tracked_keys:
+                tracked_keys.add(key)
+                entities.append(
+                    OpenWrtRadioSwitch(
+                        coordinator,
+                        entry,
+                        client,
+                        wifi.radio,
+                        wifi.band,
+                    )
+                )
+    for wifi in coordinator.data.wireless_interfaces:
         if wifi.name:
             key = f"wireless_{wifi.section or wifi.name}"
             if key not in tracked_keys:
@@ -714,6 +728,75 @@ class OpenWrtWpsSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEntity):
         self.coordinator.hass.async_create_task(
             self.coordinator.async_request_refresh()
         )
+
+
+class OpenWrtRadioSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEntity):
+    """Switch to physically enable or disable a wireless radio."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_device_class = SwitchDeviceClass.SWITCH
+
+    def __init__(
+        self,
+        coordinator: OpenWrtDataCoordinator,
+        entry: ConfigEntry,
+        client: OpenWrtClient,
+        radio: str,
+        band: str,
+    ) -> None:
+        """Initialize the physical radio switch."""
+        super().__init__(coordinator)
+        self._client = client
+        self._radio = radio
+        label = f"{radio} ({band})" if band else radio
+        self._attr_name = f"Radio {label}"
+        self._attr_unique_id = f"{entry.entry_id}_radio_{radio}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{entry.unique_id}_radio_{radio}")},
+            name=f"Radio {label}",
+            manufacturer="OpenWrt",
+            model="Wireless Radio",
+            via_device=(DOMAIN, _router_id(entry)),
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the configured physical radio state."""
+        if self.coordinator.data is None:
+            return None
+        for wifi in self.coordinator.data.wireless_interfaces:
+            if wifi.radio == self._radio:
+                return wifi.radio_enabled
+        return None
+
+    async def _async_set_enabled(self, enabled: bool) -> None:
+        """Set the configured physical radio state."""
+        try:
+            if not await self._client.set_radio_enabled(self._radio, enabled):
+                msg = f"OpenWrt rejected radio state change for {self._radio}"
+                raise HomeAssistantError(msg)
+            if self.coordinator.data:
+                for wifi in self.coordinator.data.wireless_interfaces:
+                    if wifi.radio == self._radio:
+                        wifi.radio_enabled = enabled
+            self.async_write_ha_state()
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            msg = f"Failed to change physical radio {self._radio}: {err}"
+            raise HomeAssistantError(msg) from err
+        self.coordinator.hass.async_create_task(
+            self.coordinator.async_request_refresh()
+        )
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Physically enable the radio."""
+        await self._async_set_enabled(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Physically disable the radio."""
+        await self._async_set_enabled(False)
 
 
 class OpenWrtWirelessSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEntity):

--- a/custom_components/openwrt/switch.py
+++ b/custom_components/openwrt/switch.py
@@ -303,6 +303,7 @@ def _add_wireless_switches(
                         wifi.ssid,
                         wifi.frequency,
                         wifi.section,
+                        wifi.radio,
                     ),
                 )
 
@@ -815,12 +816,14 @@ class OpenWrtWirelessSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEnt
         ssid: str,
         frequency: str = "",
         section_id: str | None = None,
+        radio: str = "",
     ) -> None:
         """Initialize the wireless switch."""
         super().__init__(coordinator)
         self._client = client
         self._iface_name = iface_name
         self._section_id = section_id
+        self._radio = radio
 
         # Build descriptive labels
         self._attr_unique_id = f"{entry.entry_id}_wireless_{section_id or iface_name}"
@@ -870,50 +873,65 @@ class OpenWrtWirelessSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEnt
             if wifi.name == self._iface_name or (
                 self._section_id and wifi.section == self._section_id
             ):
-                return wifi.enabled
+                return wifi.interface_enabled
         return None
+
+    async def _async_set_network_enabled(self, enabled: bool) -> None:
+        """Set the SSID and coordinate its physical radio."""
+        disable_radio = False
+        if not enabled and self._radio and self.coordinator.data:
+            target = self._section_id or self._iface_name
+            disable_radio = not any(
+                wifi.radio == self._radio
+                and (wifi.section or wifi.name) != target
+                and wifi.interface_enabled
+                for wifi in self.coordinator.data.wireless_interfaces
+            )
+
+        try:
+            if self._radio:
+                changed = await self._client.set_wireless_network_enabled(
+                    self._section_id or self._iface_name,
+                    self._radio,
+                    enabled,
+                    disable_radio=disable_radio,
+                )
+            else:
+                changed = await self._client.set_wireless_enabled(
+                    self._section_id or self._iface_name,
+                    enabled,
+                )
+            if not changed:
+                msg = f"OpenWrt rejected wireless state change for {self._iface_name}"
+                raise HomeAssistantError(msg)
+
+            if self.coordinator.data:
+                for wifi in self.coordinator.data.wireless_interfaces:
+                    if wifi.name == self._iface_name:
+                        wifi.interface_enabled = enabled
+                        wifi.enabled = enabled
+                    if wifi.radio == self._radio:
+                        if enabled:
+                            wifi.radio_enabled = True
+                        elif disable_radio:
+                            wifi.radio_enabled = False
+            self.async_write_ha_state()
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            msg = f"Failed to change wireless interface {self._iface_name}: {err}"
+            raise HomeAssistantError(msg) from err
+        self.coordinator.hass.async_create_task(
+            self.coordinator.async_request_refresh()
+        )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable the wireless interface."""
-        try:
-            await self._client.set_wireless_enabled(
-                self._section_id or self._iface_name, True
-            )
-            # Optimistic update
-            if self.coordinator.data:
-                for wifi in self.coordinator.data.wireless_interfaces:
-                    if wifi.name == self._iface_name or (
-                        self._section_id and wifi.section == self._section_id
-                    ):
-                        wifi.enabled = True
-            self.async_write_ha_state()
-        except Exception as err:
-            msg = f"Failed to enable wireless interface {self._iface_name}: {err}"
-            raise HomeAssistantError(msg) from err
-        self.coordinator.hass.async_create_task(
-            self.coordinator.async_request_refresh()
-        )
+        await self._async_set_network_enabled(True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable the wireless interface."""
-        try:
-            await self._client.set_wireless_enabled(
-                self._section_id or self._iface_name, False
-            )
-            # Optimistic update
-            if self.coordinator.data:
-                for wifi in self.coordinator.data.wireless_interfaces:
-                    if wifi.name == self._iface_name or (
-                        self._section_id and wifi.section == self._section_id
-                    ):
-                        wifi.enabled = False
-            self.async_write_ha_state()
-        except Exception as err:
-            msg = f"Failed to disable wireless interface {self._iface_name}: {err}"
-            raise HomeAssistantError(msg) from err
-        self.coordinator.hass.async_create_task(
-            self.coordinator.async_request_refresh()
-        )
+        await self._async_set_network_enabled(False)
 
 
 class OpenWrtServiceSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEntity):

--- a/custom_components/openwrt/switch.py
+++ b/custom_components/openwrt/switch.py
@@ -36,7 +36,6 @@ from .const import (
 )
 from .coordinator import OpenWrtDataCoordinator
 from .helpers import (
-    _router_id,
     format_ap_device_id,
     format_ap_name,
     format_radio_device_id,
@@ -761,11 +760,13 @@ class OpenWrtRadioSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEntity
         self._attr_name = "Physical radio"
         self._attr_unique_id = f"{entry.entry_id}_radio_{radio}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, format_radio_device_id(entry, radio))},
+            identifiers={
+                (DOMAIN, format_radio_device_id(coordinator.router_id, radio))
+            },
             name=label,
             manufacturer="OpenWrt",
             model="Wireless Radio",
-            via_device=(DOMAIN, _router_id(entry)),
+            via_device=(DOMAIN, coordinator.router_id),
         )
 
     @property
@@ -851,9 +852,12 @@ class OpenWrtWirelessSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEnt
 
         name_label = format_ap_name(ssid or iface_name, frequency)
 
-        via_device = (DOMAIN, _router_id(entry))
+        via_device = (DOMAIN, coordinator.router_id)
         if radio:
-            via_device = (DOMAIN, format_radio_device_id(entry, radio))
+            via_device = (
+                DOMAIN,
+                format_radio_device_id(coordinator.router_id, radio),
+            )
         self._attr_device_info = DeviceInfo(
             identifiers={
                 (DOMAIN, format_ap_device_id(coordinator.router_id, stable_id))
@@ -907,7 +911,9 @@ class OpenWrtWirelessSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEnt
 
             if self.coordinator.data:
                 for wifi in self.coordinator.data.wireless_interfaces:
-                    if wifi.name == self._iface_name:
+                    if wifi.name == self._iface_name or (
+                        self._section_id and wifi.section == self._section_id
+                    ):
                         wifi.interface_enabled = enabled
                         wifi.enabled = enabled
                     if wifi.radio == self._radio:

--- a/custom_components/openwrt/switch.py
+++ b/custom_components/openwrt/switch.py
@@ -40,6 +40,7 @@ from .helpers import (
     format_ap_device_id,
     format_ap_name,
     format_radio_device_id,
+    format_radio_name,
     normalize_band,
 )
 
@@ -756,12 +757,12 @@ class OpenWrtRadioSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEntity
         super().__init__(coordinator)
         self._client = client
         self._radio = radio
-        label = f"{radio} ({band})" if band else radio
-        self._attr_name = f"Radio {label}"
+        label = format_radio_name(radio, band)
+        self._attr_name = "Radio"
         self._attr_unique_id = f"{entry.entry_id}_radio_{radio}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, format_radio_device_id(entry, radio))},
-            name=f"Radio {label}",
+            name=label,
             manufacturer="OpenWrt",
             model="Wireless Radio",
             via_device=(DOMAIN, _router_id(entry)),
@@ -861,10 +862,10 @@ class OpenWrtWirelessSwitch(CoordinatorEntity[OpenWrtDataCoordinator], SwitchEnt
             self._attr_name = f"Radio [{iface_name}]"
 
         if radio:
-            radio_label = f"{radio} ({band})" if band else radio
+            radio_label = format_radio_name(radio, band)
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, format_radio_device_id(entry, radio))},
-                name=f"Radio {radio_label}",
+                name=radio_label,
                 manufacturer="OpenWrt",
                 model="Wireless Radio",
                 via_device=(DOMAIN, _router_id(entry)),

--- a/tests/test_api_luci_rpc.py
+++ b/tests/test_api_luci_rpc.py
@@ -97,6 +97,55 @@ async def test_luci_get_device_info(luci_client: LuciRpcClient):
 
 
 @pytest.mark.asyncio
+async def test_disabled_radio_remains_discoverable_from_uci(
+    luci_client: LuciRpcClient,
+) -> None:
+    """Keep a configured radio controllable when runtime interfaces disappear."""
+    luci_client.packages.wireless = True
+
+    async def execute(command: str) -> str:
+        if "network.wireless status" in command:
+            return (
+                '{"radio0":{"up":false,"disabled":true,'
+                '"config":{"hwmode":"11g"},"interfaces":[]}}'
+            )
+        if command == "uci export wireless":
+            return """package wireless
+
+config wifi-device 'radio0'
+\toption type 'mac80211'
+\toption band '2g'
+\toption disabled '1'
+
+config wifi-iface 'default_radio0'
+\toption device 'radio0'
+\toption mode 'ap'
+\toption ssid 'Test WiFi'
+\toption encryption 'psk2'
+"""
+        if "iwinfo devices" in command:
+            return '{"devices":[]}'
+        return ""
+
+    with patch.object(
+        luci_client,
+        "execute_command",
+        new_callable=AsyncMock,
+        side_effect=execute,
+    ):
+        interfaces = await luci_client.get_wireless_interfaces()
+
+    assert len(interfaces) == 1
+    assert interfaces[0].section == "default_radio0"
+    assert interfaces[0].radio == "radio0"
+    assert interfaces[0].ssid == "Test WiFi"
+    assert interfaces[0].interface_enabled is True
+    assert interfaces[0].radio_enabled is False
+    assert interfaces[0].enabled is False
+    assert interfaces[0].band == "2.4 GHz"
+
+
+@pytest.mark.asyncio
 async def test_luci_get_sqm_status(luci_client: LuciRpcClient):
     """Test fetching SQM status via LuCI RPC."""
     luci_client._auth_token = "luci_test_token"

--- a/tests/test_api_ssh.py
+++ b/tests/test_api_ssh.py
@@ -130,6 +130,69 @@ config wifi-iface 'guest'
 
 
 @pytest.mark.asyncio
+async def test_ssh_runtime_disabled_interface_is_not_enabled(
+    ssh_client: SshClient,
+) -> None:
+    """Keep the combined state off when only the SSID is disabled."""
+    ssh_client.packages.wireless = True
+
+    def exec_side_effect(command: str) -> str:
+        if "network.wireless status" in command:
+            return (
+                '{"radio0":{"up":true,"disabled":false,'
+                '"config":{"band":"2g"},"interfaces":['
+                '{"section":"main","ifname":"wlan0",'
+                '"config":{"ssid":"Main","disabled":true}}]}}'
+            )
+        return ""
+
+    with patch.object(
+        ssh_client,
+        "_exec",
+        new_callable=AsyncMock,
+        side_effect=exec_side_effect,
+    ):
+        interfaces = await ssh_client.get_wireless_interfaces()
+
+    assert len(interfaces) == 1
+    assert interfaces[0].radio_enabled is True
+    assert interfaces[0].interface_enabled is False
+    assert interfaces[0].enabled is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "args", "kwargs"),
+    [
+        ("set_wireless_enabled", ("radio0", False), {}),
+        (
+            "set_wireless_network_enabled",
+            ("main", "radio0", False),
+            {"disable_radio": True},
+        ),
+    ],
+)
+async def test_ssh_wireless_mutation_rejects_nonzero_remote_exit(
+    ssh_client: SshClient,
+    method_name: str,
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+) -> None:
+    """Do not report a rejected remote wireless mutation as successful."""
+    ssh_client._last_full_poll = 123
+    with patch.object(
+        ssh_client,
+        "_exec",
+        new_callable=AsyncMock,
+        return_value="command failed\n__HA_RC__:1",
+    ):
+        result = await getattr(ssh_client, method_name)(*args, **kwargs)
+
+    assert result is False
+    assert ssh_client._last_full_poll == 123
+
+
+@pytest.mark.asyncio
 async def test_ssh_get_connected_devices_iwinfo_fallback(ssh_client: SshClient):
     """Test SSH client fallback to ubus hostapd for wifi clients when iwinfo fails."""
     ssh_client._connected = True

--- a/tests/test_api_ssh.py
+++ b/tests/test_api_ssh.py
@@ -68,6 +68,68 @@ async def test_ssh_get_device_info(ssh_client: SshClient):
 
 
 @pytest.mark.asyncio
+async def test_ssh_keeps_disabled_radio_when_another_radio_is_active(
+    ssh_client: SshClient,
+) -> None:
+    """Supplement runtime data with configured interfaces from every radio."""
+    ssh_client.packages.wireless = True
+
+    def exec_side_effect(command: str) -> str:
+        if "network.wireless status" in command:
+            return (
+                '{"radio0":{"up":true,"disabled":false,'
+                '"config":{"band":"2g"},"interfaces":['
+                '{"section":"main","ifname":"wlan0",'
+                '"config":{"ssid":"Main"}}]},'
+                '"radio1":{"up":false,"disabled":true,'
+                '"config":{"band":"5g"},"interfaces":[]}}'
+            )
+        if "iwinfo devices" in command:
+            return '{"devices":["wlan0"]}'
+        if "uci export wireless" in command:
+            return """package wireless
+
+config wifi-device 'radio0'
+\toption band '2g'
+
+config wifi-device 'radio1'
+\toption band '5g'
+\toption disabled 'true'
+
+config wifi-iface 'main'
+\toption device 'radio0'
+\toption mode 'ap'
+\toption ssid 'Main'
+\toption ifname 'wlan0'
+
+config wifi-iface 'guest'
+\toption device 'radio1'
+\toption mode 'ap'
+\toption ssid 'Guest'
+"""
+        return ""
+
+    with patch.object(
+        ssh_client,
+        "_exec",
+        new_callable=AsyncMock,
+        side_effect=exec_side_effect,
+    ):
+        interfaces = await ssh_client.get_wireless_interfaces()
+
+    assert len(interfaces) == 2
+    active = next(wifi for wifi in interfaces if wifi.section == "main")
+    disabled = next(wifi for wifi in interfaces if wifi.section == "guest")
+    assert active.radio_enabled is True
+    assert active.interface_enabled is True
+    assert disabled.radio == "radio1"
+    assert disabled.band == "5 GHz"
+    assert disabled.radio_enabled is False
+    assert disabled.interface_enabled is True
+    assert disabled.enabled is False
+
+
+@pytest.mark.asyncio
 async def test_ssh_get_connected_devices_iwinfo_fallback(ssh_client: SshClient):
     """Test SSH client fallback to ubus hostapd for wifi clients when iwinfo fails."""
     ssh_client._connected = True

--- a/tests/test_api_ubus.py
+++ b/tests/test_api_ubus.py
@@ -459,6 +459,7 @@ async def test_ubus_get_wireless_interfaces_matching(ubus_client: UbusClient):
                         ],
                     },
                     "radio1": {
+                        "disabled": True,
                         "config": {"band": "5g", "hwmode": "11a"},
                         "interfaces": [
                             {
@@ -499,12 +500,14 @@ async def test_ubus_get_wireless_interfaces_matching(ubus_client: UbusClient):
         assert wifi2g.ifname == "wlan0"
         assert wifi2g.band == "2.4 GHz"
         assert wifi2g.channel == 1
+        assert wifi2g.radio_enabled is True
 
         wifi5g = next(w for w in interfaces if w.section == "default_radio1")
         assert wifi5g.name == "wlan1"
         assert wifi5g.ifname == "wlan1"
         assert wifi5g.band == "5 GHz"
         assert wifi5g.channel == 36
+        assert wifi5g.radio_enabled is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_ubus.py
+++ b/tests/test_api_ubus.py
@@ -654,24 +654,30 @@ async def test_ubus_coordinates_ssid_and_radio_in_one_transaction(
         call("uci", "commit", {"config": "wireless"}),
         call("network.wireless", "notify"),
     ]
-    assert call(
-        "uci",
-        "set",
-        {
-            "config": "wireless",
-            "section": "main",
-            "values": {"disabled": "0" if enabled else "1"},
-        },
-    ) in mock_call.await_args_list
-    assert call(
-        "uci",
-        "set",
-        {
-            "config": "wireless",
-            "section": "radio0",
-            "values": {"disabled": radio_state},
-        },
-    ) in mock_call.await_args_list
+    assert (
+        call(
+            "uci",
+            "set",
+            {
+                "config": "wireless",
+                "section": "main",
+                "values": {"disabled": "0" if enabled else "1"},
+            },
+        )
+        in mock_call.await_args_list
+    )
+    assert (
+        call(
+            "uci",
+            "set",
+            {
+                "config": "wireless",
+                "section": "radio0",
+                "values": {"disabled": radio_state},
+            },
+        )
+        in mock_call.await_args_list
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_ubus.py
+++ b/tests/test_api_ubus.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
-from custom_components.openwrt.api.ubus import UbusClient
+from custom_components.openwrt.api.ubus import UbusClient, UbusError
 
 
 @pytest.fixture
@@ -515,6 +515,44 @@ async def test_ubus_get_wireless_interfaces_matching(ubus_client: UbusClient):
 
 
 @pytest.mark.asyncio
+async def test_ubus_rejects_invalid_reported_txpower(ubus_client: UbusClient) -> None:
+    """Keep configured TX power when iwinfo reports an invalid zero value."""
+    ubus_client.packages.wireless = True
+
+    def call_side_effect(object_name, method, params=None, *args, **kwargs):
+        if object_name == "network.wireless" and method == "status":
+            return {
+                "radio0": {
+                    "config": {"band": "2g", "txpower": 17},
+                    "interfaces": [
+                        {
+                            "section": "main",
+                            "ifname": "wlan0",
+                            "config": {"ssid": "Main"},
+                        }
+                    ],
+                }
+            }
+        if object_name == "uci" and method == "get":
+            return {}
+        if object_name == "iwinfo" and method == "devices":
+            return ["wlan0"]
+        if object_name == "iwinfo" and method == "info":
+            return {"ssid": "Main", "txpower": 0}
+        return {}
+
+    with patch.object(
+        ubus_client,
+        "_call",
+        new_callable=AsyncMock,
+        side_effect=call_side_effect,
+    ):
+        interfaces = await ubus_client.get_wireless_interfaces()
+
+    assert interfaces[0].txpower == 17
+
+
+@pytest.mark.asyncio
 async def test_ubus_wireless_skips_radio_info(ubus_client: UbusClient):
     """Test that physical radio names are not queried as iwinfo interfaces."""
     ubus_client.packages.wireless = True
@@ -634,6 +672,68 @@ async def test_ubus_coordinates_ssid_and_radio_in_one_transaction(
             "values": {"disabled": radio_state},
         },
     ) in mock_call.await_args_list
+
+
+@pytest.mark.asyncio
+async def test_ubus_reverts_partial_wireless_transaction(
+    ubus_client: UbusClient,
+) -> None:
+    """Discard staged UCI changes when a pre-commit operation fails."""
+    calls = []
+
+    async def call_side_effect(object_name, method, params=None, *args, **kwargs):
+        calls.append(call(object_name, method, params))
+        if object_name == "uci" and method == "set" and params["section"] == "main":
+            raise UbusError("set failed")
+        return {}
+
+    with patch.object(
+        ubus_client,
+        "_call",
+        new_callable=AsyncMock,
+        side_effect=call_side_effect,
+    ):
+        result = await ubus_client.set_wireless_network_enabled(
+            "main",
+            "radio0",
+            True,
+            disable_radio=False,
+        )
+
+    assert result is False
+    assert call("uci", "revert", {"config": "wireless"}) in calls
+    assert call("uci", "commit", {"config": "wireless"}) not in calls
+
+
+@pytest.mark.asyncio
+async def test_ubus_does_not_revert_after_successful_commit(
+    ubus_client: UbusClient,
+) -> None:
+    """Do not undo committed state when only the wireless notification fails."""
+    calls = []
+
+    async def call_side_effect(object_name, method, params=None, *args, **kwargs):
+        calls.append(call(object_name, method, params))
+        if object_name == "network.wireless" and method == "notify":
+            raise UbusError("notify failed")
+        return {}
+
+    with patch.object(
+        ubus_client,
+        "_call",
+        new_callable=AsyncMock,
+        side_effect=call_side_effect,
+    ):
+        result = await ubus_client.set_wireless_network_enabled(
+            "main",
+            "radio0",
+            False,
+            disable_radio=True,
+        )
+
+    assert result is False
+    assert call("uci", "commit", {"config": "wireless"}) in calls
+    assert call("uci", "revert", {"config": "wireless"}) not in calls
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_ubus.py
+++ b/tests/test_api_ubus.py
@@ -1,6 +1,6 @@
 """Test the OpenWrt Ubus API client."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -585,6 +585,51 @@ async def test_ubus_wireless_skips_info_for_luci_admin_proxy(
     assert len(interfaces) == 1
     assert interfaces[0].name == "wlan06"
     assert interfaces[0].clients_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("enabled", "disable_radio", "radio_state"),
+    [(True, False, "0"), (False, True, "1")],
+)
+async def test_ubus_coordinates_ssid_and_radio_in_one_transaction(
+    ubus_client: UbusClient,
+    enabled: bool,
+    disable_radio: bool,
+    radio_state: str,
+) -> None:
+    """Commit the SSID and required radio state together."""
+    with patch.object(ubus_client, "_call", new_callable=AsyncMock) as mock_call:
+        result = await ubus_client.set_wireless_network_enabled(
+            "main",
+            "radio0",
+            enabled,
+            disable_radio=disable_radio,
+        )
+
+    assert result is True
+    assert mock_call.await_args_list[-2:] == [
+        call("uci", "commit", {"config": "wireless"}),
+        call("network.wireless", "notify"),
+    ]
+    assert call(
+        "uci",
+        "set",
+        {
+            "config": "wireless",
+            "section": "main",
+            "values": {"disabled": "0" if enabled else "1"},
+        },
+    ) in mock_call.await_args_list
+    assert call(
+        "uci",
+        "set",
+        {
+            "config": "wireless",
+            "section": "radio0",
+            "values": {"disabled": radio_state},
+        },
+    ) in mock_call.await_args_list
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_ubus.py
+++ b/tests/test_api_ubus.py
@@ -480,6 +480,7 @@ async def test_ubus_get_wireless_interfaces_matching(ubus_client: UbusClient):
                         "frequency": 5180,
                         "bssid": "00:11:22:33:44:55",
                         "channel": 36,
+                        "txpower": 23,
                     }
                 if device == "wlan0":
                     return {
@@ -487,6 +488,7 @@ async def test_ubus_get_wireless_interfaces_matching(ubus_client: UbusClient):
                         "frequency": 2412,
                         "bssid": "00:11:22:33:44:66",
                         "channel": 1,
+                        "txpower": 20,
                     }
             return {}
 
@@ -500,6 +502,7 @@ async def test_ubus_get_wireless_interfaces_matching(ubus_client: UbusClient):
         assert wifi2g.ifname == "wlan0"
         assert wifi2g.band == "2.4 GHz"
         assert wifi2g.channel == 1
+        assert wifi2g.txpower == 20
         assert wifi2g.radio_enabled is True
 
         wifi5g = next(w for w in interfaces if w.section == "default_radio1")
@@ -507,6 +510,7 @@ async def test_ubus_get_wireless_interfaces_matching(ubus_client: UbusClient):
         assert wifi5g.ifname == "wlan1"
         assert wifi5g.band == "5 GHz"
         assert wifi5g.channel == 36
+        assert wifi5g.txpower == 23
         assert wifi5g.radio_enabled is False
 
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -204,9 +204,7 @@ def test_wireless_client_is_grouped_under_its_ssid(
         "11:22:33:44:55:66_ap_Main_2.4 GHz",
     )
     registry.async_get_device.assert_called_with(
-        identifiers={
-            ("openwrt", "11:22:33:44:55:66_ap_Main_2.4 GHz")
-        }
+        identifiers={("openwrt", "11:22:33:44:55:66_ap_Main_2.4 GHz")}
     )
 
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -164,7 +164,9 @@ def test_wireless_client_is_grouped_under_its_ssid(
         connected_devices=[
             ConnectedDevice(
                 mac=mac,
-                interface="phy0-ap0",
+                # OpenWrt may report the UCI section instead of the runtime
+                # interface name for an associated wireless client.
+                interface="default_radio0",
                 is_wireless=True,
                 connected=True,
             )

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -13,7 +13,11 @@ from homeassistant.helpers import (
     device_registry as dr,
 )
 
-from custom_components.openwrt.api.base import ConnectedDevice, OpenWrtData
+from custom_components.openwrt.api.base import (
+    ConnectedDevice,
+    OpenWrtData,
+    WirelessInterface,
+)
 from custom_components.openwrt.const import (
     CONF_CONSIDER_HOME,
     CONF_TRUST_STALE_ARP,
@@ -149,6 +153,59 @@ def test_device_tracker_stable_device_info(
         assert device_info["via_device"][1] == "11:22:33:44:55:66"
         assert (dr.CONNECTION_NETWORK_MAC, mac.lower()) in device_info["connections"]
         assert any(ident[1] == mac.lower() for ident in device_info["identifiers"])
+
+
+def test_wireless_client_is_grouped_under_its_ssid(
+    mock_coordinator: MagicMock, mock_config_entry: MagicMock
+) -> None:
+    """Resolve a wireless client's interface to its nested SSID device."""
+    mac = "aa:bb:cc:dd:ee:ff"
+    mock_coordinator.data = OpenWrtData(
+        connected_devices=[
+            ConnectedDevice(
+                mac=mac,
+                interface="phy0-ap0",
+                is_wireless=True,
+                connected=True,
+            )
+        ],
+        wireless_interfaces=[
+            WirelessInterface(
+                name="phy0-ap0",
+                section="default_radio0",
+                ssid="Main",
+                radio="radio0",
+                band="2.4 GHz",
+            )
+        ],
+    )
+    mock_coordinator.interface_to_stable_id = {"phy0-ap0": "Main_2.4 GHz"}
+    radio_device = MagicMock()
+    registry = MagicMock()
+    registry.async_get_device.return_value = radio_device
+
+    with (
+        patch(
+            "homeassistant.helpers.device_registry.async_get",
+            return_value=registry,
+        ),
+        patch(
+            "custom_components.openwrt.device_tracker.DeviceInfo",
+            side_effect=lambda **kwargs: kwargs,
+        ),
+    ):
+        tracker = OpenWrtDeviceTracker(mock_coordinator, mock_config_entry, mac)
+        device_info = tracker.device_info
+
+    assert device_info["via_device"] == (
+        "openwrt",
+        "11:22:33:44:55:66_ap_Main_2.4 GHz",
+    )
+    registry.async_get_device.assert_called_with(
+        identifiers={
+            ("openwrt", "11:22:33:44:55:66_ap_Main_2.4 GHz")
+        }
+    )
 
 
 def test_device_tracker_randomized_mac(

--- a/tests/test_gps_location.py
+++ b/tests/test_gps_location.py
@@ -1,6 +1,6 @@
 """Tests for GPS location updates from Quectel modem."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -70,9 +70,15 @@ async def test_async_update_gps_location(hass):
         "===GPS_LOC===\n+QGPSLOC: 105742.00,5201.0090N,00043.0931W,0.8,78.2,3,,0.0,0.0,290626,13\nOK",  # location output
     ]
 
-    with patch.object(
-        hass.services, "async_call", new_callable=AsyncMock
-    ) as mock_service_call:
+    with (
+        patch.object(
+            hass.services, "async_call", new_callable=AsyncMock
+        ) as mock_service_call,
+        patch(
+            "custom_components.openwrt.helpers.gps.dt_util.now",
+            return_value=datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+    ):
         res = await async_update_gps_location(hass, mock_client, "/dev/ttyUSB3")
         assert res is not None
         assert res[0] == pytest.approx(52.016817)

--- a/tests/test_gps_location.py
+++ b/tests/test_gps_location.py
@@ -83,7 +83,7 @@ async def test_async_update_gps_location(hass):
         assert res is not None
         assert res[0] == pytest.approx(52.016817)
         assert res[1] == pytest.approx(-0.718218)
-        assert isinstance(res[2], datetime)
+        assert res[2] == datetime(2026, 1, 1, tzinfo=UTC)
         mock_service_call.assert_called_once_with(
             "homeassistant",
             "set_location",

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -204,3 +204,7 @@ async def test_txpower_number_is_created_once_per_radio() -> None:
         ("openwrt", "94:83:c4:ac:7a:13_radio_radio0"),
         ("openwrt", "94:83:c4:ac:7a:13_radio_radio1"),
     }
+    assert {entity._attr_device_info["name"] for entity in added_entities} == {
+        "2.4 GHz",
+        "5 GHz",
+    }

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -162,9 +162,26 @@ async def test_unknown_zero_txpower_does_not_create_entity() -> None:
     hass.data = {"openwrt": {"test_entry": {"coordinator": coordinator}}}
     added_entities = []
 
-    await async_setup_entry(hass, entry, added_entities.extend)
+    stale = MagicMock(
+        entity_id="number.radio1_tx_power",
+        domain="number",
+        unique_id="test_entry_txpower_radio1",
+    )
+    registry = MagicMock()
+    with (
+        patch(
+            "custom_components.openwrt.number.er.async_get",
+            return_value=registry,
+        ),
+        patch(
+            "custom_components.openwrt.number.er.async_entries_for_config_entry",
+            return_value=[stale],
+        ),
+    ):
+        await async_setup_entry(hass, entry, added_entities.extend)
 
     assert added_entities == []
+    registry.async_remove.assert_called_once_with("number.radio1_tx_power")
 
 
 @pytest.mark.asyncio

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -82,7 +82,7 @@ async def test_txpower_number_creation_and_control() -> None:
 
 
 def test_txpower_number_status_matching() -> None:
-    """Verify OpenWrtTxPowerNumber matches txpower using section when iface name differs."""
+    """Verify OpenWrtTxPowerNumber matches TX power by physical radio."""
     from custom_components.openwrt.coordinator import OpenWrtDataCoordinator
     from custom_components.openwrt.number import OpenWrtTxPowerNumber
 
@@ -102,10 +102,8 @@ def test_txpower_number_status_matching() -> None:
     num = OpenWrtTxPowerNumber(
         coordinator,
         config_entry,
-        "default_radio0",
-        "MyNet",
+        "radio0",
         "2.4 GHz",
-        section_id="default_radio0",
     )
     assert num.native_value == 20
 
@@ -138,9 +136,63 @@ def test_txpower_number_max_value() -> None:
     num = OpenWrtTxPowerNumber(
         coordinator,
         config_entry,
-        "default_radio0",
-        "MyNet",
+        "radio0",
         "2.4 GHz",
-        section_id="default_radio0",
     )
     assert num.native_max_value == 9.0
+
+
+@pytest.mark.asyncio
+async def test_txpower_number_is_created_once_per_radio() -> None:
+    """Create one TX power control for a radio shared by multiple SSIDs."""
+    wireless_interfaces = [
+        WirelessInterface(
+            name="phy0-ap0",
+            section="main_24g",
+            ssid="Main",
+            radio="radio0",
+            band="2.4 GHz",
+            txpower=20,
+        ),
+        WirelessInterface(
+            name="phy0-ap1",
+            section="guest_24g",
+            ssid="Guest",
+            radio="radio0",
+            band="2.4 GHz",
+            txpower=20,
+        ),
+        WirelessInterface(
+            name="phy1-ap0",
+            section="main_5g",
+            ssid="Main",
+            radio="radio1",
+            band="5 GHz",
+            txpower=23,
+        ),
+    ]
+    coordinator = MagicMock()
+    coordinator.data = OpenWrtData(
+        wireless_interfaces=wireless_interfaces,
+        permissions=OpenWrtPermissions(write_wireless=True),
+    )
+    coordinator.async_add_listener = MagicMock()
+
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.unique_id = "router_mac"
+    entry.async_on_unload = MagicMock()
+
+    added_entities: list[OpenWrtTxPowerNumber] = []
+    hass = MagicMock()
+    hass.data = {"openwrt": {"test_entry": {"coordinator": coordinator}}}
+
+    await async_setup_entry(hass, entry, added_entities.extend)
+
+    assert len(added_entities) == 2
+    assert {entity._attr_unique_id for entity in added_entities} == {
+        "test_entry_txpower_radio0",
+        "test_entry_txpower_radio1",
+    }
+    assert all(entity.entity_registry_enabled_default for entity in added_entities)
+    assert {entity.native_value for entity in added_entities} == {20, 23}

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -113,6 +113,29 @@ def test_txpower_number_status_matching() -> None:
     assert num.native_value == 14
 
 
+def test_txpower_number_uses_canonical_router_id_without_entry_unique_id() -> None:
+    """Attach TX power to the coordinator router when unique_id is not set yet."""
+    coordinator = MagicMock()
+    coordinator.router_id = "canonical_router"
+    coordinator.data = OpenWrtData(
+        wireless_interfaces=[
+            WirelessInterface(name="wlan0", radio="radio0", txpower=20)
+        ]
+    )
+    entry = MagicMock(entry_id="test_entry", unique_id=None)
+
+    with patch("custom_components.openwrt.number.DeviceInfo", side_effect=dict):
+        entity = OpenWrtTxPowerNumber(coordinator, entry, "radio0", "2.4 GHz")
+
+    assert entity._attr_device_info["identifiers"] == {
+        ("openwrt", "canonical_router_radio_radio0")
+    }
+    assert entity._attr_device_info["via_device"] == (
+        "openwrt",
+        "canonical_router",
+    )
+
+
 def test_txpower_number_max_value() -> None:
     """Verify OpenWrtTxPowerNumber native_max_value respects txpower_offset."""
     from custom_components.openwrt.coordinator import OpenWrtDataCoordinator
@@ -214,6 +237,7 @@ async def test_txpower_number_is_created_once_per_radio() -> None:
         ),
     ]
     coordinator = MagicMock()
+    coordinator.router_id = "02:00:00:00:00:01"
     coordinator.data = OpenWrtData(
         wireless_interfaces=wireless_interfaces,
         permissions=OpenWrtPermissions(write_wireless=True),
@@ -222,7 +246,7 @@ async def test_txpower_number_is_created_once_per_radio() -> None:
 
     entry = MagicMock()
     entry.entry_id = "test_entry"
-    entry.unique_id = "9483c4ac7a13"
+    entry.unique_id = "020000000001"
     entry.async_on_unload = MagicMock()
 
     added_entities: list[OpenWrtTxPowerNumber] = []
@@ -243,8 +267,8 @@ async def test_txpower_number_is_created_once_per_radio() -> None:
         next(iter(entity._attr_device_info["identifiers"]))
         for entity in added_entities
     } == {
-        ("openwrt", "94:83:c4:ac:7a:13_radio_radio0"),
-        ("openwrt", "94:83:c4:ac:7a:13_radio_radio1"),
+        ("openwrt", "02:00:00:00:00:01_radio_radio0"),
+        ("openwrt", "02:00:00:00:00:01_radio_radio1"),
     }
     assert {entity._attr_device_info["name"] for entity in added_entities} == {
         "2.4 GHz",

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -264,8 +264,7 @@ async def test_txpower_number_is_created_once_per_radio() -> None:
     assert all(entity.entity_registry_enabled_default for entity in added_entities)
     assert {entity.native_value for entity in added_entities} == {20, 23}
     assert {
-        next(iter(entity._attr_device_info["identifiers"]))
-        for entity in added_entities
+        next(iter(entity._attr_device_info["identifiers"])) for entity in added_entities
     } == {
         ("openwrt", "02:00:00:00:00:01_radio_radio0"),
         ("openwrt", "02:00:00:00:00:01_radio_radio1"),

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -18,12 +18,12 @@ from custom_components.openwrt.number import (
 
 @pytest.mark.asyncio
 async def test_txpower_number_creation_and_control() -> None:
-    """Test wireless TX Power number entities are created and work when txpower is 0 or greater."""
+    """Test a valid wireless TX power creates a controllable entity."""
     wifi = WirelessInterface(
         name="phy0-ap0",
         ssid="MyNet",
         radio="radio0",
-        txpower=0,
+        txpower=20,
     )
 
     coordinator = MagicMock()
@@ -71,7 +71,9 @@ async def test_txpower_number_creation_and_control() -> None:
     # Mock hass.data for set_native_value
     entity.hass = hass
 
-    assert entity.native_value == 0
+    assert entity.native_value == 20
+    assert entity._attr_name == "Transmit power"
+    assert entity._attr_native_min_value == 1
 
     # Test setting native value
     await entity.async_set_native_value(15)
@@ -140,6 +142,29 @@ def test_txpower_number_max_value() -> None:
         "2.4 GHz",
     )
     assert num.native_max_value == 9.0
+
+
+@pytest.mark.asyncio
+async def test_unknown_zero_txpower_does_not_create_entity() -> None:
+    """Do not expose a fabricated 0 dBm value when OpenWrt reports no power."""
+    coordinator = MagicMock()
+    coordinator.data = OpenWrtData(
+        wireless_interfaces=[
+            WirelessInterface(name="phy0-ap0", radio="radio0", txpower=0)
+        ],
+        permissions=OpenWrtPermissions(write_wireless=True),
+    )
+    coordinator.async_add_listener = MagicMock()
+
+    entry = MagicMock(entry_id="test_entry", unique_id="router_mac")
+    entry.async_on_unload = MagicMock()
+    hass = MagicMock()
+    hass.data = {"openwrt": {"test_entry": {"coordinator": coordinator}}}
+    added_entities = []
+
+    await async_setup_entry(hass, entry, added_entities.extend)
+
+    assert added_entities == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,6 +1,6 @@
 """Tests for the number platform of the OpenWrt integration."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from homeassistant.const import CONF_HOST
@@ -180,14 +180,15 @@ async def test_txpower_number_is_created_once_per_radio() -> None:
 
     entry = MagicMock()
     entry.entry_id = "test_entry"
-    entry.unique_id = "router_mac"
+    entry.unique_id = "9483c4ac7a13"
     entry.async_on_unload = MagicMock()
 
     added_entities: list[OpenWrtTxPowerNumber] = []
     hass = MagicMock()
     hass.data = {"openwrt": {"test_entry": {"coordinator": coordinator}}}
 
-    await async_setup_entry(hass, entry, added_entities.extend)
+    with patch("custom_components.openwrt.number.DeviceInfo", side_effect=dict):
+        await async_setup_entry(hass, entry, added_entities.extend)
 
     assert len(added_entities) == 2
     assert {entity._attr_unique_id for entity in added_entities} == {
@@ -196,3 +197,10 @@ async def test_txpower_number_is_created_once_per_radio() -> None:
     }
     assert all(entity.entity_registry_enabled_default for entity in added_entities)
     assert {entity.native_value for entity in added_entities} == {20, 23}
+    assert {
+        next(iter(entity._attr_device_info["identifiers"]))
+        for entity in added_entities
+    } == {
+        ("openwrt", "94:83:c4:ac:7a:13_radio_radio0"),
+        ("openwrt", "94:83:c4:ac:7a:13_radio_radio1"),
+    }

--- a/tests/test_private_data_check.py
+++ b/tests/test_private_data_check.py
@@ -1,0 +1,65 @@
+"""Behavior tests for the private-data branch scanner."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _git(repository: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_manual_scan_uses_default_branch_merge_base(tmp_path: Path) -> None:
+    """Scan every feature commit during manual workflow runs."""
+    origin = tmp_path / "origin.git"
+    repository = tmp_path / "repository"
+    _git(tmp_path, "init", "--bare", str(origin))
+    _git(tmp_path, "init", "--initial-branch=main", str(repository))
+    _git(repository, "config", "user.name", "Test User")
+    _git(repository, "config", "user.email", "test@example.invalid")
+
+    (repository / "baseline.txt").write_text("baseline\n", encoding="utf-8")
+    _git(repository, "add", "baseline.txt")
+    _git(repository, "commit", "-m", "baseline")
+    _git(repository, "remote", "add", "origin", str(origin))
+    _git(repository, "push", "-u", "origin", "main")
+    _git(repository, "switch", "-c", "feature")
+
+    private_address = "192" + ".168.42.9"
+    (repository / "installation.txt").write_text(
+        f"host={private_address}\n", encoding="utf-8"
+    )
+    _git(repository, "add", "installation.txt")
+    _git(repository, "commit", "-m", "installation data")
+    (repository / "safe.txt").write_text("safe follow-up\n", encoding="utf-8")
+    _git(repository, "add", "safe.txt")
+    _git(repository, "commit", "-m", "safe follow-up")
+
+    scanner = Path(__file__).parents[1] / ".github/scripts/check_private_data.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(scanner),
+            "--github-event-name",
+            "workflow_dispatch",
+            "--github-before",
+            "",
+            "--default-branch",
+            "main",
+        ],
+        cwd=repository,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Private-data check failed with 1 finding(s)." in result.stdout

--- a/tests/test_radio_switch.py
+++ b/tests/test_radio_switch.py
@@ -39,6 +39,7 @@ async def test_radio_switches_are_deduplicated_and_control_radio() -> None:
         ]
     )
     coordinator.interface_to_stable_id = {}
+    coordinator.router_id = "router_id"
     coordinator.async_request_refresh = AsyncMock()
     coordinator.hass.async_create_task = MagicMock(
         side_effect=lambda task: task.close()
@@ -71,14 +72,21 @@ async def test_radio_switches_are_deduplicated_and_control_radio() -> None:
         and getattr(entity, "_radio", None) == "radio0"
     ]
     assert len(radio0_entities) == 3
+    assert next(iter(radios[0]._attr_device_info["identifiers"])) == (
+        "openwrt",
+        "router_id_radio_radio0",
+    )
+    ssid_entities = [
+        entity for entity in radio0_entities if isinstance(entity, OpenWrtWirelessSwitch)
+    ]
     assert {
-        next(iter(entity._attr_device_info["identifiers"]))
-        for entity in radio0_entities
-    } == {("openwrt", "router_id_radio_radio0")}
-    assert {entity._attr_name for entity in radio0_entities} == {
-        "Physical radio",
-        "SSID phy0-ap0",
-        "SSID phy0-ap1",
+        next(iter(entity._attr_device_info["identifiers"])) for entity in ssid_entities
+    } == {
+        ("openwrt", "router_id_ap_phy0-ap0"),
+        ("openwrt", "router_id_ap_phy0-ap1"),
+    }
+    assert {entity._attr_device_info["via_device"] for entity in ssid_entities} == {
+        ("openwrt", "router_id_radio_radio0")
     }
 
     await radios[1].async_turn_on()

--- a/tests/test_radio_switch.py
+++ b/tests/test_radio_switch.py
@@ -62,6 +62,7 @@ async def test_radio_switches_are_deduplicated_and_control_radio() -> None:
         "2.4 GHz",
         "5 GHz",
     }
+    assert {entity._attr_name for entity in radios} == {"Physical radio"}
 
     radio0_entities = [
         entity
@@ -74,6 +75,11 @@ async def test_radio_switches_are_deduplicated_and_control_radio() -> None:
         next(iter(entity._attr_device_info["identifiers"]))
         for entity in radio0_entities
     } == {("openwrt", "router_id_radio_radio0")}
+    assert {entity._attr_name for entity in radio0_entities} == {
+        "Physical radio",
+        "SSID phy0-ap0",
+        "SSID phy0-ap1",
+    }
 
     await radios[1].async_turn_on()
 

--- a/tests/test_radio_switch.py
+++ b/tests/test_radio_switch.py
@@ -82,7 +82,9 @@ async def test_radio_switches_are_deduplicated_and_control_radio() -> None:
         "router_id",
     )
     ssid_entities = [
-        entity for entity in radio0_entities if isinstance(entity, OpenWrtWirelessSwitch)
+        entity
+        for entity in radio0_entities
+        if isinstance(entity, OpenWrtWirelessSwitch)
     ]
     assert {
         next(iter(entity._attr_device_info["identifiers"])) for entity in ssid_entities
@@ -102,6 +104,49 @@ async def test_radio_switches_are_deduplicated_and_control_radio() -> None:
         for wifi in coordinator.data.wireless_interfaces
         if wifi.radio == "radio1"
     )
+
+
+@pytest.mark.asyncio
+async def test_radio_change_recomputes_combined_ssid_state() -> None:
+    """Keep each SSID's combined state aligned with radio and interface state."""
+    active = WirelessInterface(
+        name="phy0-ap0",
+        radio="radio0",
+        enabled=True,
+        interface_enabled=True,
+        radio_enabled=True,
+    )
+    disabled = WirelessInterface(
+        name="phy0-ap1",
+        radio="radio0",
+        enabled=False,
+        interface_enabled=False,
+        radio_enabled=True,
+    )
+    coordinator = MagicMock()
+    coordinator.router_id = "router_id"
+    coordinator.data = OpenWrtData(wireless_interfaces=[active, disabled])
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.hass.async_create_task = MagicMock(
+        side_effect=lambda task: task.close()
+    )
+    client = MagicMock()
+    client.set_radio_enabled = AsyncMock(return_value=True)
+    switch = OpenWrtRadioSwitch(
+        coordinator,
+        MagicMock(entry_id="test_entry", unique_id="router_id"),
+        client,
+        "radio0",
+        "2.4 GHz",
+    )
+
+    await switch.async_turn_off()
+    assert active.enabled is False
+    assert disabled.enabled is False
+
+    await switch.async_turn_on()
+    assert active.enabled is True
+    assert disabled.enabled is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_switch.py
+++ b/tests/test_radio_switch.py
@@ -10,7 +10,50 @@ from custom_components.openwrt.switch import (
     OpenWrtRadioSwitch,
     OpenWrtWirelessSwitch,
     _add_wireless_switches,
+    async_setup_entry,
 )
+
+
+@pytest.mark.asyncio
+async def test_setup_removes_only_orphaned_radio_switches(hass) -> None:
+    """Remove radio switches whose physical radio is no longer discovered."""
+    coordinator = MagicMock()
+    coordinator.data = OpenWrtData(
+        wireless_interfaces=[WirelessInterface(name="phy0-ap0", radio="radio0")]
+    )
+    coordinator.async_add_listener = MagicMock()
+    coordinator._device_history = {}
+
+    entry = MagicMock(entry_id="test_entry")
+    entry.data = {}
+    entry.options = {}
+    entry.async_on_unload = MagicMock()
+    hass.data = {
+        "openwrt": {entry.entry_id: {"coordinator": coordinator, "client": MagicMock()}}
+    }
+    hass.add_job = MagicMock(side_effect=lambda callback: callback())
+
+    active = MagicMock(
+        domain="switch",
+        entity_id="switch.radio0",
+        unique_id="test_entry_radio_radio0",
+    )
+    orphaned = MagicMock(
+        domain="switch",
+        entity_id="switch.radio1",
+        unique_id="test_entry_radio_radio1",
+    )
+    registry = MagicMock()
+    with (
+        patch("custom_components.openwrt.switch.er.async_get", return_value=registry),
+        patch(
+            "custom_components.openwrt.switch.er.async_entries_for_config_entry",
+            return_value=[active, orphaned],
+        ),
+    ):
+        await async_setup_entry(hass, entry, MagicMock())
+
+    registry.async_remove.assert_called_once_with("switch.radio1")
 
 
 @pytest.mark.asyncio
@@ -250,6 +293,51 @@ async def test_enabling_ssid_also_enables_its_radio() -> None:
     assert wifi.enabled is True
     assert wifi.radio_enabled is True
     assert switch.is_on is True
+
+
+@pytest.mark.asyncio
+async def test_enabling_ssid_recomputes_enabled_sibling_state() -> None:
+    """Restore configured sibling SSIDs when their shared radio is enabled."""
+    target = WirelessInterface(
+        name="phy1-ap0",
+        section="main_5g",
+        ssid="Main",
+        radio="radio1",
+        enabled=False,
+        interface_enabled=False,
+        radio_enabled=False,
+    )
+    sibling = WirelessInterface(
+        name="phy1-ap1",
+        section="guest_5g",
+        ssid="Guest",
+        radio="radio1",
+        enabled=False,
+        interface_enabled=True,
+        radio_enabled=False,
+    )
+    coordinator = MagicMock()
+    coordinator.data = OpenWrtData(wireless_interfaces=[target, sibling])
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.hass.async_create_task = MagicMock(
+        side_effect=lambda task: task.close()
+    )
+    client = MagicMock()
+    client.set_wireless_network_enabled = AsyncMock(return_value=True)
+    switch = OpenWrtWirelessSwitch(
+        coordinator,
+        MagicMock(entry_id="test_entry", unique_id="router_id"),
+        client,
+        target.name,
+        target.ssid,
+        section_id=target.section,
+        radio=target.radio,
+    )
+
+    await switch.async_turn_on()
+
+    assert target.enabled is True
+    assert sibling.enabled is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_switch.py
+++ b/tests/test_radio_switch.py
@@ -1,0 +1,67 @@
+"""Tests for physical wireless radio switches."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.openwrt.api.base import OpenWrtData, WirelessInterface
+from custom_components.openwrt.switch import (
+    OpenWrtRadioSwitch,
+    _add_wireless_switches,
+)
+
+
+@pytest.mark.asyncio
+async def test_radio_switches_are_deduplicated_and_control_radio() -> None:
+    """Expose and control each physical radio exactly once."""
+    coordinator = MagicMock()
+    coordinator.data = OpenWrtData(
+        wireless_interfaces=[
+            WirelessInterface(
+                name="phy0-ap0",
+                radio="radio0",
+                band="2.4 GHz",
+                radio_enabled=True,
+            ),
+            WirelessInterface(
+                name="phy0-ap1",
+                radio="radio0",
+                band="2.4 GHz",
+                radio_enabled=True,
+            ),
+            WirelessInterface(
+                name="phy1-ap0",
+                radio="radio1",
+                band="5 GHz",
+                radio_enabled=False,
+            ),
+        ]
+    )
+    coordinator.interface_to_stable_id = {}
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.hass.async_create_task = MagicMock(
+        side_effect=lambda task: task.close()
+    )
+
+    entry = MagicMock(entry_id="test_entry", unique_id="router_id")
+    client = MagicMock()
+    client.set_radio_enabled = AsyncMock(return_value=True)
+    entities = []
+
+    _add_wireless_switches(coordinator, entry, client, entities, set())
+
+    radios = [entity for entity in entities if isinstance(entity, OpenWrtRadioSwitch)]
+    assert [entity._attr_unique_id for entity in radios] == [
+        "test_entry_radio_radio0",
+        "test_entry_radio_radio1",
+    ]
+    assert [entity.is_on for entity in radios] == [True, False]
+
+    await radios[1].async_turn_on()
+
+    client.set_radio_enabled.assert_awaited_once_with("radio1", True)
+    assert all(
+        wifi.radio_enabled
+        for wifi in coordinator.data.wireless_interfaces
+        if wifi.radio == "radio1"
+    )

--- a/tests/test_radio_switch.py
+++ b/tests/test_radio_switch.py
@@ -7,6 +7,7 @@ import pytest
 from custom_components.openwrt.api.base import OpenWrtData, WirelessInterface
 from custom_components.openwrt.switch import (
     OpenWrtRadioSwitch,
+    OpenWrtWirelessSwitch,
     _add_wireless_switches,
 )
 
@@ -65,3 +66,106 @@ async def test_radio_switches_are_deduplicated_and_control_radio() -> None:
         for wifi in coordinator.data.wireless_interfaces
         if wifi.radio == "radio1"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("other_interface_enabled", "expected_disable_radio"),
+    [(False, True), (True, False)],
+)
+async def test_disabling_ssid_powers_down_only_an_unused_radio(
+    other_interface_enabled: bool,
+    expected_disable_radio: bool,
+) -> None:
+    """Power down a radio only after its last configured SSID is disabled."""
+    target = WirelessInterface(
+        name="phy0-ap0",
+        section="main",
+        ssid="Main",
+        radio="radio0",
+        interface_enabled=True,
+        radio_enabled=True,
+    )
+    sibling = WirelessInterface(
+        name="phy0-ap1",
+        section="guest",
+        ssid="Guest",
+        radio="radio0",
+        interface_enabled=other_interface_enabled,
+        radio_enabled=True,
+    )
+    coordinator = MagicMock()
+    coordinator.data = OpenWrtData(wireless_interfaces=[target, sibling])
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.hass.async_create_task = MagicMock(
+        side_effect=lambda task: task.close()
+    )
+    client = MagicMock()
+    client.set_wireless_network_enabled = AsyncMock(return_value=True)
+    switch = OpenWrtWirelessSwitch(
+        coordinator,
+        MagicMock(entry_id="test_entry", unique_id="router_id"),
+        client,
+        target.name,
+        target.ssid,
+        section_id=target.section,
+        radio=target.radio,
+    )
+    assert switch.is_on is True
+
+    await switch.async_turn_off()
+
+    client.set_wireless_network_enabled.assert_awaited_once_with(
+        "main",
+        "radio0",
+        False,
+        disable_radio=expected_disable_radio,
+    )
+    assert target.interface_enabled is False
+    assert target.enabled is False
+    assert target.radio_enabled is not expected_disable_radio
+    assert switch.is_on is False
+
+
+@pytest.mark.asyncio
+async def test_enabling_ssid_also_enables_its_radio() -> None:
+    """Restore the physical radio whenever an SSID is enabled."""
+    wifi = WirelessInterface(
+        name="phy1-ap0",
+        section="main_5g",
+        ssid="Main",
+        radio="radio1",
+        interface_enabled=False,
+        radio_enabled=False,
+    )
+    coordinator = MagicMock()
+    coordinator.data = OpenWrtData(wireless_interfaces=[wifi])
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.hass.async_create_task = MagicMock(
+        side_effect=lambda task: task.close()
+    )
+    client = MagicMock()
+    client.set_wireless_network_enabled = AsyncMock(return_value=True)
+    switch = OpenWrtWirelessSwitch(
+        coordinator,
+        MagicMock(entry_id="test_entry", unique_id="router_id"),
+        client,
+        wifi.name,
+        wifi.ssid,
+        section_id=wifi.section,
+        radio=wifi.radio,
+    )
+    assert switch.is_on is False
+
+    await switch.async_turn_on()
+
+    client.set_wireless_network_enabled.assert_awaited_once_with(
+        "main_5g",
+        "radio1",
+        True,
+        disable_radio=False,
+    )
+    assert wifi.interface_enabled is True
+    assert wifi.enabled is True
+    assert wifi.radio_enabled is True
+    assert switch.is_on is True

--- a/tests/test_radio_switch.py
+++ b/tests/test_radio_switch.py
@@ -58,6 +58,10 @@ async def test_radio_switches_are_deduplicated_and_control_radio() -> None:
         "test_entry_radio_radio1",
     ]
     assert [entity.is_on for entity in radios] == [True, False]
+    assert {entity._attr_device_info["name"] for entity in radios} == {
+        "2.4 GHz",
+        "5 GHz",
+    }
 
     radio0_entities = [
         entity

--- a/tests/test_radio_switch.py
+++ b/tests/test_radio_switch.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.openwrt.api.base import OpenWrtData, WirelessInterface
 from custom_components.openwrt.switch import (
@@ -45,7 +46,7 @@ async def test_radio_switches_are_deduplicated_and_control_radio() -> None:
         side_effect=lambda task: task.close()
     )
 
-    entry = MagicMock(entry_id="test_entry", unique_id="router_id")
+    entry = MagicMock(entry_id="test_entry", unique_id="stale_router_id")
     client = MagicMock()
     client.set_radio_enabled = AsyncMock(return_value=True)
     entities = []
@@ -75,6 +76,10 @@ async def test_radio_switches_are_deduplicated_and_control_radio() -> None:
     assert next(iter(radios[0]._attr_device_info["identifiers"])) == (
         "openwrt",
         "router_id_radio_radio0",
+    )
+    assert radios[0]._attr_device_info["via_device"] == (
+        "openwrt",
+        "router_id",
     )
     ssid_entities = [
         entity for entity in radio0_entities if isinstance(entity, OpenWrtWirelessSwitch)
@@ -200,3 +205,93 @@ async def test_enabling_ssid_also_enables_its_radio() -> None:
     assert wifi.enabled is True
     assert wifi.radio_enabled is True
     assert switch.is_on is True
+
+
+@pytest.mark.asyncio
+async def test_rejected_radio_change_preserves_coordinator_state() -> None:
+    """Do not optimistically update a radio after a rejected command."""
+    wifi = WirelessInterface(name="wlan0", radio="radio0", radio_enabled=True)
+    coordinator = MagicMock()
+    coordinator.router_id = "router_id"
+    coordinator.data = OpenWrtData(wireless_interfaces=[wifi])
+    client = MagicMock()
+    client.set_radio_enabled = AsyncMock(return_value=False)
+    switch = OpenWrtRadioSwitch(
+        coordinator,
+        MagicMock(entry_id="test_entry", unique_id="router_id"),
+        client,
+        "radio0",
+        "2.4 GHz",
+    )
+
+    with pytest.raises(HomeAssistantError):
+        await switch.async_turn_off()
+
+    assert wifi.radio_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_rejected_ssid_change_preserves_coordinator_state() -> None:
+    """Do not optimistically update an SSID after a rejected command."""
+    wifi = WirelessInterface(
+        name="wlan0",
+        section="main",
+        radio="radio0",
+        interface_enabled=True,
+        radio_enabled=True,
+    )
+    coordinator = MagicMock()
+    coordinator.router_id = "router_id"
+    coordinator.data = OpenWrtData(wireless_interfaces=[wifi])
+    client = MagicMock()
+    client.set_wireless_network_enabled = AsyncMock(return_value=False)
+    switch = OpenWrtWirelessSwitch(
+        coordinator,
+        MagicMock(entry_id="test_entry", unique_id="router_id"),
+        client,
+        wifi.name,
+        "Main",
+        section_id=wifi.section,
+        radio=wifi.radio,
+    )
+
+    with pytest.raises(HomeAssistantError):
+        await switch.async_turn_off()
+
+    assert wifi.interface_enabled is True
+    assert wifi.radio_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_section_matched_ssid_gets_optimistic_update() -> None:
+    """Update an SSID whose runtime name differs from its UCI section."""
+    wifi = WirelessInterface(
+        name="wlan0",
+        section="main",
+        radio="radio0",
+        interface_enabled=True,
+        radio_enabled=True,
+    )
+    coordinator = MagicMock()
+    coordinator.router_id = "router_id"
+    coordinator.data = OpenWrtData(wireless_interfaces=[wifi])
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.hass.async_create_task = MagicMock(
+        side_effect=lambda task: task.close()
+    )
+    client = MagicMock()
+    client.set_wireless_network_enabled = AsyncMock(return_value=True)
+    switch = OpenWrtWirelessSwitch(
+        coordinator,
+        MagicMock(entry_id="test_entry", unique_id="router_id"),
+        client,
+        "main",
+        "Main",
+        section_id="main",
+        radio="radio0",
+    )
+
+    await switch.async_turn_off()
+
+    assert wifi.interface_enabled is False
+    assert wifi.enabled is False

--- a/tests/test_radio_switch.py
+++ b/tests/test_radio_switch.py
@@ -1,6 +1,6 @@
 """Tests for physical wireless radio switches."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -49,7 +49,8 @@ async def test_radio_switches_are_deduplicated_and_control_radio() -> None:
     client.set_radio_enabled = AsyncMock(return_value=True)
     entities = []
 
-    _add_wireless_switches(coordinator, entry, client, entities, set())
+    with patch("custom_components.openwrt.switch.DeviceInfo", side_effect=dict):
+        _add_wireless_switches(coordinator, entry, client, entities, set())
 
     radios = [entity for entity in entities if isinstance(entity, OpenWrtRadioSwitch)]
     assert [entity._attr_unique_id for entity in radios] == [
@@ -57,6 +58,18 @@ async def test_radio_switches_are_deduplicated_and_control_radio() -> None:
         "test_entry_radio_radio1",
     ]
     assert [entity.is_on for entity in radios] == [True, False]
+
+    radio0_entities = [
+        entity
+        for entity in entities
+        if isinstance(entity, (OpenWrtRadioSwitch, OpenWrtWirelessSwitch))
+        and getattr(entity, "_radio", None) == "radio0"
+    ]
+    assert len(radio0_entities) == 3
+    assert {
+        next(iter(entity._attr_device_info["identifiers"]))
+        for entity in radio0_entities
+    } == {("openwrt", "router_id_radio_radio0")}
 
     await radios[1].async_turn_on()
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -88,8 +88,8 @@ def test_wifi_sensor_ap_mode_suppression() -> None:
     assert "wifi_wlan1_bitrate" in keys_sta
 
 
-def test_wifi_sensors_are_grouped_under_their_physical_radio() -> None:
-    """Put SSID metrics on the radio device instead of a separate AP device."""
+def test_wifi_sensors_are_grouped_under_their_ssid_below_the_radio() -> None:
+    """Put SSID metrics on an SSID device nested below its physical radio."""
     from custom_components.openwrt.sensor import _create_wifi_sensors
 
     coordinator = MagicMock()
@@ -120,8 +120,11 @@ def test_wifi_sensors_are_grouped_under_their_physical_radio() -> None:
     assert sensors
     assert {
         next(iter(sensor._attr_device_info["identifiers"])) for sensor in sensors
-    } == {("openwrt", "router_mac_radio_radio0")}
-    assert {sensor._attr_device_info["name"] for sensor in sensors} == {"2.4 GHz"}
+    } == {("openwrt", "router_mac_ap_Main_2.4 GHz")}
+    assert {sensor._attr_device_info["name"] for sensor in sensors} == {"SSID Main"}
+    assert {sensor._attr_device_info["via_device"] for sensor in sensors} == {
+        ("openwrt", "router_mac_radio_radio0")
+    }
 
 
 def test_device_sensor_case_insensitivity() -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 
 from homeassistant.components.sensor import SensorDeviceClass
 
-from custom_components.openwrt.api.base import OpenWrtData, SystemResources
+from custom_components.openwrt.api.base import (
+    OpenWrtData,
+    SystemResources,
+    WirelessInterface,
+)
 from custom_components.openwrt.sensor import OpenWrtSensorEntity, _get_system_sensors
 
 
@@ -82,6 +86,42 @@ def test_wifi_sensor_ap_mode_suppression() -> None:
     assert "wifi_wlan1_signal" in keys_sta
     assert "wifi_wlan1_quality" in keys_sta
     assert "wifi_wlan1_bitrate" in keys_sta
+
+
+def test_wifi_sensors_are_grouped_under_their_physical_radio() -> None:
+    """Put SSID metrics on the radio device instead of a separate AP device."""
+    from custom_components.openwrt.sensor import _create_wifi_sensors
+
+    coordinator = MagicMock()
+    coordinator.router_id = "router_mac"
+    coordinator.interface_to_stable_id = {"phy0-ap0": "Main_2.4 GHz"}
+    coordinator.data = OpenWrtData(
+        wireless_interfaces=[
+            WirelessInterface(
+                name="phy0-ap0",
+                ssid="Main",
+                radio="radio0",
+                band="2.4 GHz",
+            )
+        ]
+    )
+    entry = MagicMock(entry_id="test", unique_id="router_mac")
+
+    with patch("custom_components.openwrt.sensor.DeviceInfo", side_effect=dict):
+        sensors = _create_wifi_sensors(
+            coordinator,
+            entry,
+            "phy0-ap0",
+            "Main",
+            "ap",
+            "2.4 GHz",
+        )
+
+    assert sensors
+    assert {
+        next(iter(sensor._attr_device_info["identifiers"])) for sensor in sensors
+    } == {("openwrt", "router_mac_radio_radio0")}
+    assert {sensor._attr_device_info["name"] for sensor in sensors} == {"2.4 GHz"}
 
 
 def test_device_sensor_case_insensitivity() -> None:

--- a/tests/test_wireless_device_grouping.py
+++ b/tests/test_wireless_device_grouping.py
@@ -401,7 +401,11 @@ async def test_coordinator_orphan_cleanup_ghost_sections(hass):
 
 def test_router_id_mac_formatting_prevents_duplicate_ap():
     """Verify that MAC address formatting in unique_id ensures stable router and AP device identification."""
-    from custom_components.openwrt.helpers import _router_id, format_ap_device_id
+    from custom_components.openwrt.helpers import (
+        _router_id,
+        format_ap_device_id,
+        format_radio_device_id,
+    )
 
     # 1. Test helper extraction formatting
     config_entry = MagicMock()
@@ -416,3 +420,67 @@ def test_router_id_mac_formatting_prevents_duplicate_ap():
         format_ap_device_id(config_entry, "stable_ssid_5 GHz")
         == "94:83:c4:ac:7a:13_ap_stable_ssid_5 GHz"
     )
+    assert (
+        format_radio_device_id(config_entry, "radio0")
+        == "94:83:c4:ac:7a:13_radio_radio0"
+    )
+
+
+@pytest.mark.asyncio
+async def test_coordinator_preserves_active_radio_device(hass):
+    """Keep a configured physical radio during registry cleanup."""
+    from custom_components.openwrt.api.base import (
+        DeviceInfo,
+        OpenWrtData,
+        WirelessInterface,
+    )
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.unique_id = "router_mac"
+    config_entry.data = {"host": "192.0.2.1"}
+    config_entry.options = {}
+    coordinator = OpenWrtDataCoordinator(hass, config_entry, MagicMock())
+    coordinator.router_id = "router_mac"
+
+    router_dev = MagicMock()
+    router_dev.id = "router_dev_id"
+    router_dev.identifiers = {(DOMAIN, "router_mac")}
+
+    radio_dev = MagicMock()
+    radio_dev.id = "radio_dev_id"
+    radio_dev.name = "Radio radio0 (2.4 GHz)"
+    radio_dev.identifiers = {(DOMAIN, "router_mac_radio_radio0")}
+    radio_dev.config_entries = {"test_entry"}
+    radio_dev.via_device_id = "router_dev_id"
+    radio_dev.disabled_by = None
+    radio_dev.entry_type = None
+    radio_dev.manufacturer = "OpenWrt"
+    radio_dev.model = "Wireless Radio"
+
+    device_registry = MagicMock()
+    device_registry.devices = {
+        router_dev.id: router_dev,
+        radio_dev.id: radio_dev,
+    }
+    device_registry.async_get_device.return_value = router_dev
+
+    data = OpenWrtData(
+        device_info=DeviceInfo(mac_address="router_mac"),
+        wireless_interfaces=[
+            WirelessInterface(
+                name="phy0-ap0",
+                ssid="Test",
+                radio="radio0",
+                band="2.4 GHz",
+            )
+        ],
+    )
+
+    with patch(
+        "homeassistant.helpers.device_registry.async_get",
+        return_value=device_registry,
+    ):
+        await coordinator._async_update_device_registry(data)
+
+    device_registry.async_remove_device.assert_not_called()

--- a/tests/test_wireless_device_grouping.py
+++ b/tests/test_wireless_device_grouping.py
@@ -514,3 +514,40 @@ async def test_coordinator_preserves_active_radio_device(hass):
         DOMAIN,
         "router_mac_radio_radio0",
     )
+
+
+def test_coordinator_reparents_existing_wireless_client_to_ssid(hass) -> None:
+    """Move an existing client device below its currently associated SSID."""
+    from custom_components.openwrt.api.base import ConnectedDevice, OpenWrtData
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.unique_id = "router_mac"
+    config_entry.data = {"host": "192.0.2.1"}
+    config_entry.options = {}
+    coordinator = OpenWrtDataCoordinator(hass, config_entry, MagicMock())
+
+    client = MagicMock(id="client_id", via_device_id="router_id")
+    ssid = MagicMock(id="ssid_id")
+    registry = MagicMock()
+    registry.async_get_device.side_effect = [client, ssid]
+    data = OpenWrtData(
+        connected_devices=[
+            ConnectedDevice(
+                mac="02:00:00:00:00:01",
+                interface="phy0-ap0",
+                is_wireless=True,
+                connected=True,
+            )
+        ]
+    )
+
+    with patch(
+        "custom_components.openwrt.coordinator.get_via_device",
+        return_value=(DOMAIN, "router_mac_ap_Main_2.4 GHz"),
+    ):
+        coordinator._async_reparent_connected_devices(data, registry)
+
+    registry.async_update_device.assert_called_once_with(
+        "client_id", via_device_id="ssid_id"
+    )

--- a/tests/test_wireless_device_grouping.py
+++ b/tests/test_wireless_device_grouping.py
@@ -404,6 +404,7 @@ def test_router_id_mac_formatting_prevents_duplicate_ap():
     from custom_components.openwrt.helpers import (
         _router_id,
         format_ap_device_id,
+        format_ap_name,
         format_radio_device_id,
         format_radio_name,
     )
@@ -427,6 +428,7 @@ def test_router_id_mac_formatting_prevents_duplicate_ap():
     )
     assert format_radio_name("radio0", "2.4 GHz") == "2.4 GHz"
     assert format_radio_name("radio0", "") == "radio0"
+    assert format_ap_name("Main", "2.4 GHz") == "SSID Main"
 
 
 @pytest.mark.asyncio
@@ -500,4 +502,15 @@ async def test_coordinator_preserves_active_radio_device(hass):
         for identifier in call.kwargs.get("identifiers", set())
     ]
     assert (DOMAIN, "router_mac_radio_radio0") in created_identifiers
-    assert not any("_ap_" in identifier for _domain, identifier in created_identifiers)
+    assert (DOMAIN, "router_mac_ap_Test_2.4 GHz") in created_identifiers
+    ap_call = next(
+        call
+        for call in device_registry.async_get_or_create.call_args_list
+        if (DOMAIN, "router_mac_ap_Test_2.4 GHz")
+        in call.kwargs.get("identifiers", set())
+    )
+    assert ap_call.kwargs["name"] == "SSID Test"
+    assert ap_call.kwargs["via_device"] == (
+        DOMAIN,
+        "router_mac_radio_radio0",
+    )

--- a/tests/test_wireless_device_grouping.py
+++ b/tests/test_wireless_device_grouping.py
@@ -211,9 +211,7 @@ def test_ap_stable_id_consistency() -> None:
 
     coordinator = MagicMock()
     coordinator.router_id = "router_mac"
-    coordinator.interface_to_stable_id = {
-        "phy0-ap0": "radio0_SSID_2.4 GHz"
-    }
+    coordinator.interface_to_stable_id = {"phy0-ap0": "radio0_SSID_2.4 GHz"}
 
     entry = MagicMock()
     entry.unique_id = "router_mac"
@@ -236,9 +234,7 @@ def test_ap_stable_id_consistency() -> None:
     device_info = entity._attr_device_info
     from custom_components.openwrt.helpers import format_ap_device_id
 
-    expected_id = format_ap_device_id(
-        "router_mac", "radio0_SSID_2.4 GHz"
-    )
+    expected_id = format_ap_device_id("router_mac", "radio0_SSID_2.4 GHz")
     assert (DOMAIN, expected_id) in device_info["identifiers"]
 
 

--- a/tests/test_wireless_device_grouping.py
+++ b/tests/test_wireless_device_grouping.py
@@ -414,7 +414,6 @@ def test_router_id_mac_formatting_prevents_duplicate_ap():
         format_ap_device_id,
         format_ap_name,
         format_radio_device_id,
-        format_radio_name,
     )
 
     # 1. Test helper extraction formatting
@@ -434,9 +433,19 @@ def test_router_id_mac_formatting_prevents_duplicate_ap():
         format_radio_device_id(config_entry, "radio0")
         == "94:83:c4:ac:7a:13_radio_radio0"
     )
-    assert format_radio_name("radio0", "2.4 GHz") == "2.4 GHz"
-    assert format_radio_name("radio0", "") == "radio0"
     assert format_ap_name("Main", "2.4 GHz") == "SSID Main"
+
+
+def test_format_radio_name_normalizes_uci_band_aliases() -> None:
+    """Use concise frequency names for raw and previously formatted UCI bands."""
+    from custom_components.openwrt.helpers import format_radio_name
+
+    assert format_radio_name("radio0", "2.4 GHz") == "2.4 GHz"
+    assert format_radio_name("radio0", "2g") == "2.4 GHz"
+    assert format_radio_name("radio0", "2g GHz") == "2.4 GHz"
+    assert format_radio_name("radio1", "5g") == "5 GHz"
+    assert format_radio_name("radio2", "6g") == "6 GHz"
+    assert format_radio_name("radio0", "") == "radio0"
 
 
 @pytest.mark.asyncio

--- a/tests/test_wireless_device_grouping.py
+++ b/tests/test_wireless_device_grouping.py
@@ -1,6 +1,6 @@
 """Tests for wireless interface discovery and Access Point device grouping."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -594,3 +594,44 @@ def test_coordinator_reparents_existing_wireless_client_to_ssid(hass) -> None:
         "client_id", via_device_id="ssid_id"
     )
     registry.async_get_device.assert_not_called()
+
+
+def test_coordinator_reparents_with_legacy_device_registry(hass) -> None:
+    """Retain compatibility with HA releases before scoped registry lookups."""
+    from custom_components.openwrt.api.base import ConnectedDevice, OpenWrtData
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.unique_id = "router_mac"
+    config_entry.data = {"host": "192.0.2.1"}
+    config_entry.options = {}
+    coordinator = OpenWrtDataCoordinator(hass, config_entry, MagicMock())
+
+    client = MagicMock(id="client_id", via_device_id="router_id")
+    ssid = MagicMock(id="ssid_id")
+    registry = MagicMock(spec=["async_get_device", "async_update_device"])
+    registry.async_get_device.side_effect = [client, ssid]
+    data = OpenWrtData(
+        connected_devices=[
+            ConnectedDevice(
+                mac="02:00:00:00:00:01",
+                interface="phy0-ap0",
+                is_wireless=True,
+                connected=True,
+            )
+        ]
+    )
+
+    with patch(
+        "custom_components.openwrt.coordinator.get_via_device",
+        return_value=(DOMAIN, "router_mac_ap_Main_2.4 GHz"),
+    ):
+        coordinator._async_reparent_connected_devices(data, registry)
+
+    assert registry.async_get_device.call_args_list == [
+        call(identifiers={(DOMAIN, "02:00:00:00:00:01")}),
+        call(identifiers={(DOMAIN, "router_mac_ap_Main_2.4 GHz")}),
+    ]
+    registry.async_update_device.assert_called_once_with(
+        "client_id", via_device_id="ssid_id"
+    )

--- a/tests/test_wireless_device_grouping.py
+++ b/tests/test_wireless_device_grouping.py
@@ -405,6 +405,7 @@ def test_router_id_mac_formatting_prevents_duplicate_ap():
         _router_id,
         format_ap_device_id,
         format_radio_device_id,
+        format_radio_name,
     )
 
     # 1. Test helper extraction formatting
@@ -424,6 +425,8 @@ def test_router_id_mac_formatting_prevents_duplicate_ap():
         format_radio_device_id(config_entry, "radio0")
         == "94:83:c4:ac:7a:13_radio_radio0"
     )
+    assert format_radio_name("radio0", "2.4 GHz") == "2.4 GHz"
+    assert format_radio_name("radio0", "") == "radio0"
 
 
 @pytest.mark.asyncio
@@ -449,7 +452,7 @@ async def test_coordinator_preserves_active_radio_device(hass):
 
     radio_dev = MagicMock()
     radio_dev.id = "radio_dev_id"
-    radio_dev.name = "Radio radio0 (2.4 GHz)"
+    radio_dev.name = "2.4 GHz"
     radio_dev.identifiers = {(DOMAIN, "router_mac_radio_radio0")}
     radio_dev.config_entries = {"test_entry"}
     radio_dev.via_device_id = "router_dev_id"

--- a/tests/test_wireless_device_grouping.py
+++ b/tests/test_wireless_device_grouping.py
@@ -238,8 +238,8 @@ def test_ap_stable_id_consistency() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ap_deduplication_and_naming() -> None:
-    """Verify AP deduplication and disambiguation naming logic."""
+async def test_ap_deduplication_keeps_user_facing_names_clean() -> None:
+    """Hide runtime interface IDs when equal SSIDs share an AP device."""
     from custom_components.openwrt.api.base import WirelessInterface
     from custom_components.openwrt.sensor import OpenWrtWifiSensorEntity
     from custom_components.openwrt.switch import OpenWrtWirelessSwitch
@@ -272,23 +272,31 @@ async def test_ap_deduplication_and_naming() -> None:
     desc = MagicMock()
     desc.key = "signal"
     desc.name = "Signal"
-    s1 = OpenWrtWifiSensorEntity(
-        coordinator, config_entry, desc, "phy1-ap1", "MyNet", "2.4 GHz"
-    )
-    s2 = OpenWrtWifiSensorEntity(
-        coordinator, config_entry, desc, "phy1-ap2", "MyNet", "2.4 GHz"
-    )
-    assert "phy1-ap1" in s1._attr_name
-    assert "phy1-ap2" in s2._attr_name
+    with (
+        patch("custom_components.openwrt.sensor.DeviceInfo", side_effect=dict),
+        patch("custom_components.openwrt.switch.DeviceInfo", side_effect=dict),
+    ):
+        s1 = OpenWrtWifiSensorEntity(
+            coordinator, config_entry, desc, "phy1-ap1", "MyNet", "2.4 GHz"
+        )
+        s2 = OpenWrtWifiSensorEntity(
+            coordinator, config_entry, desc, "phy1-ap2", "MyNet", "2.4 GHz"
+        )
+        sw1 = OpenWrtWirelessSwitch(
+            coordinator, config_entry, MagicMock(), "phy1-ap1", "MyNet", "2.4 GHz"
+        )
+        sw2 = OpenWrtWirelessSwitch(
+            coordinator, config_entry, MagicMock(), "phy1-ap2", "MyNet", "2.4 GHz"
+        )
+    assert getattr(s1, "_attr_name", None) is None
+    assert getattr(s2, "_attr_name", None) is None
+    assert s1._attr_device_info["name"] == "SSID MyNet"
+    assert s2._attr_device_info["name"] == "SSID MyNet"
 
-    sw1 = OpenWrtWirelessSwitch(
-        coordinator, config_entry, MagicMock(), "phy1-ap1", "MyNet", "2.4 GHz"
-    )
-    sw2 = OpenWrtWirelessSwitch(
-        coordinator, config_entry, MagicMock(), "phy1-ap2", "MyNet", "2.4 GHz"
-    )
-    assert "phy1-ap1" in sw1._attr_name
-    assert "phy1-ap2" in sw2._attr_name
+    assert sw1._attr_name == "SSID MyNet"
+    assert sw2._attr_name == "SSID MyNet"
+    assert sw1._attr_device_info["name"] == "SSID MyNet"
+    assert sw2._attr_device_info["name"] == "SSID MyNet"
 
 
 def test_wireless_switch_status_matching() -> None:

--- a/tests/test_wireless_device_grouping.py
+++ b/tests/test_wireless_device_grouping.py
@@ -494,3 +494,10 @@ async def test_coordinator_preserves_active_radio_device(hass):
         manufacturer="OpenWrt",
         model="Wireless Radio",
     )
+    created_identifiers = [
+        identifier
+        for call in device_registry.async_get_or_create.call_args_list
+        for identifier in call.kwargs.get("identifiers", set())
+    ]
+    assert (DOMAIN, "router_mac_radio_radio0") in created_identifiers
+    assert not any("_ap_" in identifier for _domain, identifier in created_identifiers)

--- a/tests/test_wireless_device_grouping.py
+++ b/tests/test_wireless_device_grouping.py
@@ -326,7 +326,7 @@ def test_wireless_switch_status_matching() -> None:
     )
     assert sw.is_on is True
 
-    wifi_iface.enabled = False
+    wifi_iface.interface_enabled = False
     assert sw.is_on is False
 
 

--- a/tests/test_wireless_device_grouping.py
+++ b/tests/test_wireless_device_grouping.py
@@ -7,6 +7,7 @@ import pytest
 from custom_components.openwrt.api.ubus import UbusClient
 from custom_components.openwrt.const import DOMAIN
 from custom_components.openwrt.coordinator import OpenWrtDataCoordinator
+from custom_components.openwrt.helpers import format_ap_stable_id
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -190,16 +191,16 @@ async def test_coordinator_stable_id_uses_band(ubus_client: UbusClient):
         if not wifi.name or not wifi.ssid:
             continue
         band = wifi.band or wifi.frequency or wifi.radio or "unknown"
-        stable_id = f"{wifi.ssid}_{band}"
+        stable_id = format_ap_stable_id(wifi.ssid, band, wifi.radio)
         ap_stable_ids.add(stable_id)
 
     assert len(ap_stable_ids) == 5
     expected_bands = {
-        "MyNet-Guest_5 GHz",
-        "MyNet-Guest_2.4 GHz",
-        "MyNet_2.4 GHz",
-        "MyNet_5 GHz",
-        "MyNet-IoT_2.4 GHz",
+        "radio0_MyNet-Guest_5 GHz",
+        "radio1_MyNet-Guest_2.4 GHz",
+        "radio1_MyNet_2.4 GHz",
+        "radio2_MyNet_5 GHz",
+        "radio1_MyNet-IoT_2.4 GHz",
     }
     assert ap_stable_ids == expected_bands
 
@@ -210,7 +211,9 @@ def test_ap_stable_id_consistency() -> None:
 
     coordinator = MagicMock()
     coordinator.router_id = "router_mac"
-    coordinator.interface_to_stable_id = {"phy0-ap0": "SSID_2.4 GHz"}
+    coordinator.interface_to_stable_id = {
+        "phy0-ap0": "radio0_SSID_2.4 GHz"
+    }
 
     entry = MagicMock()
     entry.unique_id = "router_mac"
@@ -233,7 +236,9 @@ def test_ap_stable_id_consistency() -> None:
     device_info = entity._attr_device_info
     from custom_components.openwrt.helpers import format_ap_device_id
 
-    expected_id = format_ap_device_id("router_mac", "SSID_2.4 GHz")
+    expected_id = format_ap_device_id(
+        "router_mac", "radio0_SSID_2.4 GHz"
+    )
     assert (DOMAIN, expected_id) in device_info["identifiers"]
 
 
@@ -253,8 +258,18 @@ async def test_ap_deduplication_keeps_user_facing_names_clean() -> None:
     coordinator = OpenWrtDataCoordinator(MagicMock(), config_entry, MagicMock())
     coordinator.data = MagicMock()
     coordinator.data.wireless_interfaces = [
-        WirelessInterface(name="phy1-ap1", ssid="MyNet", frequency="2.4 GHz"),
-        WirelessInterface(name="phy1-ap2", ssid="MyNet", frequency="2.4 GHz"),
+        WirelessInterface(
+            name="phy1-ap1",
+            ssid="MyNet",
+            frequency="2.4 GHz",
+            radio="radio1",
+        ),
+        WirelessInterface(
+            name="phy1-ap2",
+            ssid="MyNet",
+            frequency="2.4 GHz",
+            radio="radio1",
+        ),
     ]
 
     from custom_components.openwrt.helpers import format_ap_name
@@ -263,7 +278,7 @@ async def test_ap_deduplication_keeps_user_facing_names_clean() -> None:
     coordinator.interface_to_stable_id = {}
     for wifi in coordinator.data.wireless_interfaces:
         band = wifi.band or wifi.frequency or wifi.radio or "unknown"
-        stable_id = f"{wifi.ssid}_{band}"
+        stable_id = format_ap_stable_id(wifi.ssid, band, wifi.radio)
         ap_info[stable_id] = format_ap_name(wifi.ssid, band)
         coordinator.interface_to_stable_id[wifi.name] = stable_id
 
@@ -297,6 +312,16 @@ async def test_ap_deduplication_keeps_user_facing_names_clean() -> None:
     assert sw2._attr_name == "SSID MyNet"
     assert sw1._attr_device_info["name"] == "SSID MyNet"
     assert sw2._attr_device_info["name"] == "SSID MyNet"
+
+
+def test_same_ssid_and_band_stay_distinct_across_radios() -> None:
+    """Do not merge equal SSIDs broadcast by different physical radios."""
+    radio0_id = format_ap_stable_id("Main", "2.4 GHz", "radio0")
+    radio1_id = format_ap_stable_id("Main", "2.4 GHz", "radio1")
+
+    assert radio0_id == "radio0_Main_2.4 GHz"
+    assert radio1_id == "radio1_Main_2.4 GHz"
+    assert radio0_id != radio1_id
 
 
 def test_wireless_switch_status_matching() -> None:
@@ -418,20 +443,20 @@ def test_router_id_mac_formatting_prevents_duplicate_ap():
 
     # 1. Test helper extraction formatting
     config_entry = MagicMock()
-    config_entry.unique_id = "9483c4ac7a13"
+    config_entry.unique_id = "020000000001"
     config_entry.data = {"host": "192.168.1.1"}
 
     # Extract router ID should format the MAC
-    assert _router_id(config_entry) == "94:83:c4:ac:7a:13"
+    assert _router_id(config_entry) == "02:00:00:00:00:01"
 
     # Format AP device ID should use the formatted MAC
     assert (
         format_ap_device_id(config_entry, "stable_ssid_5 GHz")
-        == "94:83:c4:ac:7a:13_ap_stable_ssid_5 GHz"
+        == "02:00:00:00:00:01_ap_stable_ssid_5 GHz"
     )
     assert (
         format_radio_device_id(config_entry, "radio0")
-        == "94:83:c4:ac:7a:13_radio_radio0"
+        == "02:00:00:00:00:01_radio_radio0"
     )
     assert format_ap_name("Main", "2.4 GHz") == "SSID Main"
 
@@ -519,11 +544,11 @@ async def test_coordinator_preserves_active_radio_device(hass):
         for identifier in call.kwargs.get("identifiers", set())
     ]
     assert (DOMAIN, "router_mac_radio_radio0") in created_identifiers
-    assert (DOMAIN, "router_mac_ap_Test_2.4 GHz") in created_identifiers
+    assert (DOMAIN, "router_mac_ap_radio0_Test_2.4 GHz") in created_identifiers
     ap_call = next(
         call
         for call in device_registry.async_get_or_create.call_args_list
-        if (DOMAIN, "router_mac_ap_Test_2.4 GHz")
+        if (DOMAIN, "router_mac_ap_radio0_Test_2.4 GHz")
         in call.kwargs.get("identifiers", set())
     )
     assert ap_call.kwargs["name"] == "SSID Test"
@@ -547,7 +572,7 @@ def test_coordinator_reparents_existing_wireless_client_to_ssid(hass) -> None:
     client = MagicMock(id="client_id", via_device_id="router_id")
     ssid = MagicMock(id="ssid_id")
     registry = MagicMock()
-    registry.async_get_device.side_effect = [client, ssid]
+    registry.async_get_device_by_identifier.side_effect = [client, ssid]
     data = OpenWrtData(
         connected_devices=[
             ConnectedDevice(
@@ -568,3 +593,4 @@ def test_coordinator_reparents_existing_wireless_client_to_ssid(hass) -> None:
     registry.async_update_device.assert_called_once_with(
         "client_id", via_device_id="ssid_id"
     )
+    registry.async_get_device.assert_not_called()

--- a/tests/test_wireless_device_grouping.py
+++ b/tests/test_wireless_device_grouping.py
@@ -452,7 +452,7 @@ async def test_coordinator_preserves_active_radio_device(hass):
 
     radio_dev = MagicMock()
     radio_dev.id = "radio_dev_id"
-    radio_dev.name = "2.4 GHz"
+    radio_dev.name = "Radio radio0 (2.4 GHz)"
     radio_dev.identifiers = {(DOMAIN, "router_mac_radio_radio0")}
     radio_dev.config_entries = {"test_entry"}
     radio_dev.via_device_id = "router_dev_id"
@@ -467,6 +467,7 @@ async def test_coordinator_preserves_active_radio_device(hass):
         radio_dev.id: radio_dev,
     }
     device_registry.async_get_device.return_value = router_dev
+    device_registry.async_get_or_create.return_value = radio_dev
 
     data = OpenWrtData(
         device_info=DeviceInfo(mac_address="router_mac"),
@@ -487,3 +488,9 @@ async def test_coordinator_preserves_active_radio_device(hass):
         await coordinator._async_update_device_registry(data)
 
     device_registry.async_remove_device.assert_not_called()
+    device_registry.async_update_device.assert_any_call(
+        "radio_dev_id",
+        name="2.4 GHz",
+        manufacturer="OpenWrt",
+        model="Wireless Radio",
+    )


### PR DESCRIPTION
## Summary

This change models each physical Wi-Fi radio as its own Home Assistant device,
groups its SSID devices below it, and adds direct radio and transmit-power
controls while preserving independent per-SSID switches.

It also fixes recovery for disabled radios. OpenWrt may omit runtime interfaces
when a physical radio is down; the integration supplements runtime data with
the configured interfaces so entities remain controllable instead of becoming
`unknown`.

## Changes

- Add a device and switch for each discovered physical radio.
- Add one transmit-power number entity per supported physical radio.
- Attach SSID devices to their parent radio using `via_device`.
- Keep individual SSID switches independent; equal SSID names are not grouped.
- Ensure that enabling an SSID also enables its parent radio.
- Preserve configured SSIDs when directly disabling the complete radio.
- Merge LuCI/SSH runtime wireless state with UCI configuration.
- Normalize `2g`, `5g`, and `6g` band identifiers to `2.4 GHz`, `5 GHz`, and
  `6 GHz`.
- Preserve device names explicitly assigned by the Home Assistant user.

## Review follow-up

The focused commits (`34e0b96`, `cfd736c`) address the remaining review and CI
findings together:

- combine SSH radio and interface disabled flags when deriving SSID state;
- reject SSH wireless mutations when the remote command exits non-zero;
- recompute the combined SSID state after an optimistic radio update;
- assert the patched GPS timestamp exactly in its regression test;
- apply Ruff 0.16.4 formatting exactly as used by the upstream workflow;
- keep private-data patterns out of the fork workflow environment and prevent
  checkout credentials from being persisted.

The final follow-up also removes orphaned radio switches, recomputes configured
sibling SSID states when a shared radio is enabled, and scans the full feature
branch during manual or initial fork-workflow runs.

Earlier review follow-ups in this PR also make coordinated UBus changes
transactional, validate transmit-power values, stabilize router/radio/SSID
identifiers, and support both stable and development Home Assistant registry
APIs.

## Behaviour

- Disabling one SSID does not affect other configured SSIDs on the same radio.
- Direct radio control intentionally affects the complete physical radio.
- A disabled radio remains discoverable as `off` and can be enabled again.
- Enabling an SSID recovers a disabled parent radio.
- Transmit-power controls are scoped to the physical radio and are exposed only
  when supported by the backend/device.

## Validation

- Complete suite: **344 passed**.
- Ruff 0.16.4 lint and clean-archive format checks pass.
- mypy passes for the seven affected production modules.
- Private-data self-test, diff scan, and staged scan pass.
- The exact committed package was installed on Home Assistant Core `2026.8.2`.
- Reversible live tests passed against two different anonymized OpenWrt devices:
  radio off/on, individual SSID off/on, transmit-power change/restore, and
  radio-to-SSID hierarchy. Every initial state was restored.
- Reference OpenWrt system: `25.12.5` (`r33051-f5dae5ece4`), kernel `6.12.94`,
  target `ath79/generic`, architecture `mips_24kc`, apk-tools `3.0.5`.
- Integration version under test: `2.4.7-dev0`; test runtime: Python `3.13.1`
  and pytest `9.1.1`.

No site names, local addresses, real SSIDs, MAC addresses, credentials, or
serial identifiers are included.

## Non-goals

- No built-in scheduler; Home Assistant automations can schedule radio state and
  transmit power.
- No automatic grouping of equal SSIDs across radios.
- No automatic channel or transmit-power optimization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate controls for physical Wi-Fi radios and individual SSIDs.
  * Wireless devices are organized by router, radio, and SSID.
  * Added radio-level transmit-power controls with improved band and device labeling.
  * Wi-Fi sensors and connected devices appear under the relevant SSID and radio.
* **Bug Fixes**
  * Disabled and configured interfaces are discovered more reliably.
  * Improved handling of invalid transmit-power readings and radio state changes.
  * Prevented device collisions when identical SSIDs use multiple radios.
  * Coordinated SSID and radio changes now handle failures safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
