### PR TITLE
fix(coordinator): stop truncating boot time to the full hour

### DIFF
--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -432,12 +432,18 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
             utc_now = dt_util.utcnow()
             # Calculate what the boot time would be based on current uptime
             boot_time_raw = utc_now - timedelta(seconds=uptime)
-            if uptime >= 3600:
-                # More than 1 hour: Round to start of hour to reduce state changes
-                new_boot_time = boot_time_raw.replace(minute=0, second=0, microsecond=0)
-            else:
-                # Less than 1 hour: Round to start of minute
-                new_boot_time = boot_time_raw.replace(second=0, microsecond=0)
+            # Round to the nearest minute. Rounding to the full hour once
+            # uptime exceeded 3600 s discarded the minute component, so a
+            # router booted at 05:02 was reported as 05:00, and one booted
+            # at 05:47 also as 05:00 - an error of up to 59 minutes.
+            # Adding 30 s before truncating rounds to the nearest minute
+            # rather than always flooring, which would report a boot time
+            # up to 59 s early. Poll jitter is already absorbed by the
+            # >60 s stabilization check below, which is what keeps the
+            # sensor from flickering.
+            new_boot_time = (boot_time_raw + timedelta(seconds=30)).replace(
+                second=0, microsecond=0
+            )
 
             # Stabilization logic:
             # If we don't have a boot time yet, set it.

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -517,11 +517,7 @@ def _get_system_sensors() -> tuple[OpenWrtSensorDescription, ...]:
             attrs_fn=lambda data: {
                 "days": data.system_resources.uptime // 86400,
                 "hours": (data.system_resources.uptime % 86400) // 3600,
-                "minutes": (
-                    (data.system_resources.uptime % 3600) // 60
-                    if data.system_resources.uptime < 3600
-                    else None
-                ),
+                "minutes": (data.system_resources.uptime % 3600) // 60,
             },
         ),
         OpenWrtSensorDescription(


### PR DESCRIPTION
Fixes #129

The uptime sensor rounded the calculated boot time down to the start of the
hour once uptime exceeded 3600 s, discarding the minute component. A router
booted at 05:02 was reported as 05:00; one booted at 05:47 also as 05:00.

Rounding to the minute is sufficient. Poll jitter can shift the result by at
most one minute, i.e. `diff == 60`, which fails the existing `diff > 60` check
and is therefore absorbed — that check, not the truncation, is what prevents
the flickering reported in #34.

The same 3600 s condition also blanked the `minutes` attribute. Attributes
never feed the state machine, so there was nothing to suppress there either.

**Verified on OpenWrt 25.12.5 (ubus), integration v2.4.6:**

| | before | after |
|---|---|---|
| `uptime` | `05:00` | `05:02` (actual boot 05:02:12) |
| attribute `minutes` | `null` | `6` |

Tested live for several hours with uptime well above the 3600 s threshold,
where the old code would have shown `05:00`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uptime reporting for devices that have been running for one hour or longer.
  * Uptime values now consistently show elapsed minutes within the current hour instead of becoming unavailable.
  * Boot times are now aligned to the beginning of the minute for more consistent calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->