### PR TITLE
fix(mwan3): report Online Ratio as a percentage, not raw seconds

### DIFF
--- a/custom_components/openwrt/api/ubus/network.py
+++ b/custom_components/openwrt/api/ubus/network.py
@@ -22,6 +22,18 @@ UBUS_ID_AUTH = 1
 UBUS_ID_CALL = 2
 
 
+def _as_seconds(value: Any) -> float:
+    """Coerce a ubus duration field to float seconds.
+
+    Routers occasionally omit these fields or report them as null, in which
+    case float() would raise and abort the whole status response.
+    """
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def _valid_txpower(value: Any) -> int:
     """Return a positive dBm value, or zero when OpenWrt has no reading."""
     try:
@@ -604,11 +616,21 @@ class UbusNetworkMixin:
             data = await self._call("mwan3", "status")
             interfaces = data.get("interfaces", {})
             for iface_name, iface_data in interfaces.items():
+                # mwan3 reports "online" and "uptime" as durations in
+                # seconds. online_ratio is expected to be the fraction of
+                # uptime spent online; passing the raw seconds through made
+                # the sensor display values in the millions of percent.
+                online_secs = _as_seconds(iface_data.get("online"))
+                uptime_secs = _as_seconds(iface_data.get("uptime"))
                 statuses.append(
                     MwanStatus(
                         interface_name=iface_name,
                         status=iface_data.get("status", "unknown"),
-                        online_ratio=float(iface_data.get("online", 0)),
+                        online_ratio=(
+                            min(online_secs / uptime_secs, 1.0)
+                            if uptime_secs > 0
+                            else 0.0
+                        ),
                         uptime=iface_data.get("uptime", 0),
                         enabled=iface_data.get("enabled", False),
                     ),

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -2721,6 +2721,7 @@ def _create_mwan_sensors(
                 name=f"MWAN {iface_name} Online Ratio",
                 native_unit_of_measurement=PERCENTAGE,
                 state_class=SensorStateClass.MEASUREMENT,
+                suggested_display_precision=2,
                 value_fn=lambda data, n=iface_name: next(
                     (
                         m.online_ratio * 100


### PR DESCRIPTION
Fixes #130

The MWAN Online Ratio sensors displayed values in the millions of percent
(e.g. `1,318,600 %`). No ratio was computed: the parser passed mwan3's
`online` field — a duration in seconds — straight into `online_ratio`, and
the sensor multiplied it by 100.

Now the ratio is computed where both values come from the same snapshot.
`min(..., 1.0)` guards against `online` exceeding `uptime` by a second due to
sampling. With `online_ratio` a real 0–1 fraction, the existing `* 100` in
`sensor.py` is correct as is.

`suggested_display_precision=2` is added because a percentage otherwise
renders as `99.9864065792157 %`. Display only — long-term statistics keep the
full value.

**Verified on OpenWrt 25.12.5 (ubus), integration v2.4.6:**

| Interface | online / uptime | expected | sensor after fix |
|---|---|---|---|
| wan | 14769 / 14771 s | 99.9865 % | 99.9864 % |
| 5g_wan | 25554 / 25591 s | 99.8554 % | 99.8551 % |

(The residual difference is the few seconds between the sensor poll and the
manual `ubus` reading.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the MWAN3 online-ratio measurement to accurately reflect uptime spent online.
  - Returns 0 when uptime data is unavailable and prevents values from exceeding 100%.

- **Style**
  - The online-ratio sensor now displays values with two decimal places.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->