### PR TITLE
fix(mqtt): respect device whitelist in MQTT presence discovery

### DIFF
--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -1313,6 +1313,13 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                     hostname_registry[cleaned[0]] = cleaned[1]
                     registry_dirty = True
 
+            # Filter by whitelist if configured
+            if whitelist and mac not in whitelist:
+                _LOGGER.debug(
+                    "Skipping device %s: not in tracked_devices whitelist", mac
+                )
+                continue
+
             # Handle MQTT Discovery if enabled. Prefer a name another entry
             # resolved -- _mqtt_discovered suppresses a later republish, so a
             # MAC published now would stick.
@@ -1320,13 +1327,6 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 await self._async_discovery_mqtt_device(
                     mac, hostname_registry.get(mac) or mac
                 )
-
-            # Filter by whitelist if configured
-            if whitelist and mac not in whitelist:
-                _LOGGER.debug(
-                    "Skipping device %s: not in tracked_devices whitelist", mac
-                )
-                continue
 
             filtered_devices.append(device)
 
@@ -1508,11 +1508,14 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 "Cleaning up" if clean else "Starting",
                 len(self._device_history),
             )
+            whitelist = self._async_get_tracked_devices_whitelist()
             for mac, hist_data in list(self._device_history.items()):
                 # Always cleanup legacy topics to be sure
                 await self._async_discovery_mqtt_device_cleanup(mac)
 
                 if not clean:
+                    if whitelist and mac not in whitelist:
+                        continue
                     await self._async_discovery_mqtt_device(
                         mac, hist_data.get("hostname") or mac
                     )


### PR DESCRIPTION
## Description

Fixes an issue where MQTT presence discovery (`_async_discovery_mqtt_device`) was triggered for all discovered network clients prior to checking the `tracked_devices` / `manual_tracked_devices` whitelist.

### Motivation and context:
When `mqtt_presence` is enabled, all connected devices (including guest phones and randomized MACs) were being published to MQTT discovery, causing Home Assistant to create unwanted `device_tracker` entities for unlisted devices and rendering the device whitelist ineffective for MQTT presence.

### Changes made:
1. **`coordinator.py` (`_async_update_data`)**: Moved `_async_discovery_mqtt_device` below the whitelist check (`if whitelist and mac not in whitelist:`). Retained `hostname_registry` updating above the whitelist check so multi-AP hostname resolution continues to function.
2. **`coordinator.py` (`_async_setup_mqtt_discovery`)**: Added a check against `_async_get_tracked_devices_whitelist()` when looping through `self._device_history` to prevent unlisted historical devices from being published on reload/re-setup.

Fixes #135 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran the unit test suite locally covering coordinator, MQTT presence, and selective tracking logic:
- `pytest tests/test_mqtt_presence.py tests/test_coordinator.py tests/test_selective_tracking.py` (38 passed)
- All 344 core component tests passed.

- [x] Unit Tests

## Checklist:

- [x] My code follows the style guidelines of this project (`make lint`)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes (`make test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MQTT discovery now only exposes devices included in the configured whitelist.
  * Historical devices excluded from the whitelist are no longer republished.
  * Legacy discovery topics for removed devices continue to be cleaned up.
  * Hostname registry updates remain available for tracked devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->