### PR TITLE
fix(mqtt): remove invalid via_device string in MQTT discovery payload

### DIFF
--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -1682,7 +1682,6 @@ class OpenWrtDataCoordinator(DataUpdateCoordinator[OpenWrtData]):
                 "connections": [["mac", mac]],
                 "identifiers": [f"openwrt_{mac}"],
                 "name": hostname,
-                "via_device": self.router_id,
             },
         }
 


### PR DESCRIPTION
## Description

Fixes #137

When **MQTT Presence Detection** is enabled in `ha-openwrt`, Home Assistant automatically creates an unwanted, empty **"Unnamed Device"** container in the Device Registry under the MQTT integration.

### Root Cause & Solution
1. **Root Cause**: The MQTT Auto-Discovery payload included `"via_device": self.router_id`. Home Assistant Core's MQTT component (`homeassistant/components/mqtt/entity.py`) hardcodes parent device lookup to the `mqtt` domain (`("mqtt", via_device_value)`). Since the parent router is created by the `openwrt` integration (`("openwrt", router_mac)`), cross-domain lookup fails, causing HA Core's `ensure_via_device_exists()` to create a dummy "Unnamed Device" stub.
2. **Solution**: Removed `"via_device": self.router_id` from `_async_discovery_mqtt_device()`. The integration's existing Python backend method `_async_reparent_connected_devices()` natively attaches client devices to their correct topology nodes (Radio/SSID/Router) in HA's `DeviceRegistry` using MAC connections (`dr.CONNECTION_NETWORK_MAC`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit Tests
- [x] Tested on actual hardware (OpenWrt Version: 23.05, Device: x86/ARM router with Home Assistant MQTT integration)

## Checklist:

- [x] My code follows the style guidelines of this project (`make lint`)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes (`make test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MQTT-discovered device trackers are no longer incorrectly linked to the router device.
  * Tracker devices now appear independently in the device registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->